### PR TITLE
SAV-5264 Update deployment pipeline

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: cleanup-gh-pages
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     if: github.event.ref_type == 'branch'

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,31 @@
+name: Cleanup Storybook Preview
+
+on:
+  delete:
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview folder
+        run: |
+          BRANCH_NAME="${{ github.event.ref }}"
+          PREVIEW_DIR="preview/${BRANCH_NAME}"
+          if [ -d "$PREVIEW_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$PREVIEW_DIR"
+            git commit -m "chore: remove storybook preview for ${BRANCH_NAME}"
+            git push
+          else
+            echo "No preview folder found for ${BRANCH_NAME}, skipping."
+          fi

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
@@ -32,21 +30,20 @@ jobs:
       - name: Build Storybook
         run: npm run storybook-build
 
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy release to root
+        if: github.event_name == 'release'
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: storybook-static
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: storybook-static
+          destination_dir: .
+          keep_files: true
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy preview from branch
+        if: github.event_name == 'workflow_dispatch'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: storybook-static
+          destination_dir: preview/${{ github.ref_name }}
+          keep_files: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@registrucentras/rc-ses-react-components",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@fontsource/public-sans": "^5.0.18",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
   "author": "VĮ REGISTRŲ CENTRAS",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "RC SES React komponentų biblioteka",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## 🔗 Task

[SAV-5264](https://jira.registrucentras.lt/jira/browse/SAV-5264)

## 🧾 Summary

Adds CI/CD workflows for deploying Storybook to GitHub Pages.

- **`deploy-storybook.yml`** — builds and deploys Storybook on every release (to root `/`) and on manual `workflow_dispatch` (to `preview/<branch-name>/`), enabling both stable release and in-progress previews at separate URLs
- **`cleanup-preview.yml`** — automatically removes the `preview/<branch-name>/` folder from `gh-pages` branch when a branch is deleted

## 📸 Screenshots

N/A — infrastructure/workflow changes only

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable) — N/A
* [x] Tests added/updated — N/A
* [x] UI matches approved design (Figma) — N/A
* [x] Accessibility reviewed (keyboard navigation, labels, semantics) — N/A

## ⚠️ Risks

- The `gh-pages` branch must not be manually modified to avoid conflicts with automated deploys