### PR TITLE
SAV-5284: add ButtonWithPopover, FormControlWrapper, PhoneInputFormControl, ServiceHeader, ServicePage stories

### DIFF
--- a/src/stories/components/actions/ButtonWithPopover.stories.tsx
+++ b/src/stories/components/actions/ButtonWithPopover.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import RcSesButtonWithPopover from '@/components/common/Button/ButtonWithPopover'
+
+const meta: Meta<typeof RcSesButtonWithPopover> = {
+  title: 'components/actions/ButtonWithPopover',
+  component: RcSesButtonWithPopover,
+  tags: ['autodocs'],
+  argTypes: {
+    popoverHeader: { control: 'text' },
+    popoverContent: { control: 'text' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    popoverHeader: 'Information',
+    popoverContent: 'Hover or click the question icon to see this popover content',
+  },
+}
+
+export const WithCustomContent: Story = {
+  args: {
+    popoverHeader: 'Help',
+    popoverContent: 'This is custom content inside the popover',
+  },
+  render: (args) => (
+    <RcSesButtonWithPopover {...args}>Custom Button</RcSesButtonWithPopover>
+  ),
+}

--- a/src/stories/components/form/FormControlWrapper.stories.tsx
+++ b/src/stories/components/form/FormControlWrapper.stories.tsx
@@ -1,0 +1,35 @@
+import TextField from '@mui/material/TextField'
+import { Meta, StoryObj } from '@storybook/react'
+
+import RcSesFormControlWrapper from '@/components/form/components/FormControlWrapper'
+
+const meta: Meta<typeof RcSesFormControlWrapper> = {
+  title: 'components/form/FormControlWrapper',
+  component: RcSesFormControlWrapper,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    description: { control: 'text' },
+    hideLabel: { control: 'boolean' },
+    labelOnTop: { control: 'boolean' },
+    required: { control: 'boolean' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    label: 'Label',
+    description: 'This is a helpful description',
+    hideLabel: false,
+    labelOnTop: false,
+    required: false,
+  },
+  render: (args) => (
+    <RcSesFormControlWrapper {...args}>
+      <TextField id='input' placeholder='Type text here' size='small' fullWidth />
+    </RcSesFormControlWrapper>
+  ),
+}

--- a/src/stories/components/inputs/PhoneInputFormControl.stories.tsx
+++ b/src/stories/components/inputs/PhoneInputFormControl.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { useForm } from 'react-hook-form'
+
+import RcSesPhoneInputFormControl from '@/components/form/inputs/PhoneInputFormControl'
+
+const meta: Meta<typeof RcSesPhoneInputFormControl> = {
+  title: 'components/inputs/PhoneInputFormControl',
+  component: RcSesPhoneInputFormControl,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function PhoneInputFormControlDemo({ label = 'Phone Number' }: { label?: string }) {
+  const { control } = useForm({
+    defaultValues: {
+      phone: '',
+    },
+  })
+
+  return <RcSesPhoneInputFormControl control={control} label={label} name='phone' />
+}
+
+export const Default: Story = {
+  args: {
+    label: 'Phone Number',
+  },
+  render: ({ label }) => <PhoneInputFormControlDemo label={label} />,
+}

--- a/src/stories/components/layout/ServiceHeader.stories.tsx
+++ b/src/stories/components/layout/ServiceHeader.stories.tsx
@@ -1,0 +1,36 @@
+import Typography from '@mui/material/Typography'
+import { Meta, StoryObj } from '@storybook/react'
+
+import RcSesServiceHeader from '@/components/layout/ServiceHeader'
+
+const meta: Meta<typeof RcSesServiceHeader> = {
+  title: 'components/layout/ServiceHeader',
+  component: RcSesServiceHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    children: { control: 'text' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: 'Service Title',
+    children: 'This is a description of the service.',
+    breadcrumbsProps: {
+      path: [
+        { label: 'Home', path: '/' },
+        { label: 'Services', path: '/services' },
+        { label: 'Service Title', path: '/services/service' },
+      ],
+    },
+  },
+  render: (args) => (
+    <RcSesServiceHeader title={args.title} breadcrumbsProps={args.breadcrumbsProps}>
+      {args.children && <Typography variant='body1'>{args.children}</Typography>}
+    </RcSesServiceHeader>
+  ),
+}

--- a/src/stories/components/layout/ServicePage.stories.tsx
+++ b/src/stories/components/layout/ServicePage.stories.tsx
@@ -1,0 +1,26 @@
+import Typography from '@mui/material/Typography'
+import { Meta, StoryObj } from '@storybook/react'
+
+import RcSesServicePage from '@/components/layout/ServicePage'
+
+const meta: Meta<typeof RcSesServicePage> = {
+  title: 'components/layout/ServicePage',
+  component: RcSesServicePage,
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <RcSesServicePage>
+      <Typography variant='h2' sx={{ mb: 2 }}>
+        Page Content
+      </Typography>
+      <Typography variant='body1'>
+        This is the main content area of the service page.
+      </Typography>
+    </RcSesServicePage>
+  ),
+}


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/SAV-5284

## 🧾 Summary

Added 5 new components to the Storybook:

**ButtonWithPopover
FormControlWrapper 
PhoneInputFormControl
ServiceHeader
ServicePage**

## 📸 Screenshots

It's best to check components in the Storybook. Adding a couple examples below.

FormControlWrapper:

<img width="1878" height="1024" alt="image" src="https://github.com/user-attachments/assets/4dcfd61e-86ad-45ae-a87b-b774c9fac2e3" />


ServiceHeader:

<img width="1856" height="756" alt="Screenshot 2026-04-27 133720" src="https://github.com/user-attachments/assets/6c5b4f9b-1c5c-4175-8c9c-97cfefe4d834" />

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

<!-- Potential regressions or trade-offs -->

N/A
