### PR TITLE
SAV-5284: add Foundations/Colors tokens to the Storybook for display

### DIFF
--- a/src/stories/Colors.mdx
+++ b/src/stories/Colors.mdx
@@ -1,0 +1,127 @@
+import { Meta } from '@storybook/blocks'
+import { primary, secondary, grey, warning, error } from '@/theme/palette'
+
+<Meta title="Foundations/Colors" />
+
+# 🎨 Color Palette
+
+All color tokens used throughout RC SES React Components are defined centrally in `src/theme/palette.tsx` and can be imported from the library.
+
+## Primary Color
+Used for main actions, links, and interactive elements.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '12px', marginBottom: '32px' }}>
+  {Object.entries(primary).map(([key, value]) => (
+    <div key={key} style={{ textAlign: 'center' }}>
+      <div style={{
+        width: '100%',
+        height: '80px',
+        backgroundColor: value,
+        borderRadius: '8px',
+        marginBottom: '8px',
+        border: '1px solid #ddd'
+      }} />
+      <div style={{ fontSize: '12px', fontWeight: '600' }}>{key}</div>
+      <div style={{ fontSize: '11px', color: '#666', fontFamily: 'monospace' }}>{value}</div>
+    </div>
+  ))}
+</div>
+
+## Secondary Color
+Used for secondary actions and highlights.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '12px', marginBottom: '32px' }}>
+  {Object.entries(secondary).map(([key, value]) => (
+    <div key={key} style={{ textAlign: 'center' }}>
+      <div style={{
+        width: '100%',
+        height: '80px',
+        backgroundColor: value,
+        borderRadius: '8px',
+        marginBottom: '8px',
+        border: '1px solid #ddd'
+      }} />
+      <div style={{ fontSize: '12px', fontWeight: '600' }}>{key}</div>
+      <div style={{ fontSize: '11px', color: '#666', fontFamily: 'monospace' }}>{value}</div>
+    </div>
+  ))}
+</div>
+
+## Neutral Colors (Grey)
+Used for text, borders, backgrounds, and disabled states.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '12px', marginBottom: '32px' }}>
+  {Object.entries(grey).map(([key, value]) => (
+    <div key={key} style={{ textAlign: 'center' }}>
+      <div style={{
+        width: '100%',
+        height: '80px',
+        backgroundColor: value,
+        borderRadius: '8px',
+        marginBottom: '8px',
+        border: '1px solid #ddd'
+      }} />
+      <div style={{ fontSize: '12px', fontWeight: '600' }}>{key}</div>
+      <div style={{ fontSize: '11px', color: '#666', fontFamily: 'monospace' }}>{value}</div>
+    </div>
+  ))}
+</div>
+
+## Warning Color
+Used for warning messages and alerts.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '12px', marginBottom: '32px' }}>
+  {Object.entries(warning).map(([key, value]) => (
+    <div key={key} style={{ textAlign: 'center' }}>
+      <div style={{
+        width: '100%',
+        height: '80px',
+        backgroundColor: value,
+        borderRadius: '8px',
+        marginBottom: '8px',
+        border: '1px solid #ddd'
+      }} />
+      <div style={{ fontSize: '12px', fontWeight: '600' }}>{key}</div>
+      <div style={{ fontSize: '11px', color: '#666', fontFamily: 'monospace' }}>{value}</div>
+    </div>
+  ))}
+</div>
+
+## Error Color
+Used for error messages and destructive actions.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '12px', marginBottom: '32px' }}>
+  {Object.entries(error).map(([key, value]) => (
+    <div key={key} style={{ textAlign: 'center' }}>
+      <div style={{
+        width: '100%',
+        height: '80px',
+        backgroundColor: value,
+        borderRadius: '8px',
+        marginBottom: '8px',
+        border: '1px solid #ddd'
+      }} />
+      <div style={{ fontSize: '12px', fontWeight: '600' }}>{key}</div>
+      <div style={{ fontSize: '11px', color: '#666', fontFamily: 'monospace' }}>{value}</div>
+    </div>
+  ))}
+</div>
+
+## Usage
+
+Import and use color tokens in your components:
+
+```typescript
+// Import the entire palette
+import palette from '@/theme/palette'
+
+// Use in components
+<Box sx={{ backgroundColor: palette.primary['50'] }} />
+
+// Or destructure specific colors
+import { primary, error, grey } from '@/theme/palette'
+
+const color = primary['600']
+```
+
+


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/SAV-5284

## 🧾 Summary

Added `Foundations/Colors` section in the Storybook to visually display available color tokens. Every time something changes or a new color gets added in the `palette.tsx`, colors in the Storybook will automatically update (no manual update needed), so documentation stays in sync.

## 📸 Screenshots

It's best to check in the Storybook, but here's a sneak peak:

<img width="377" height="817" alt="image" src="https://github.com/user-attachments/assets/f45ccd0e-990a-4b96-8e3e-82bb3cc6c86b" />



<!-- Visual proof of changes -->

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

<!-- Potential regressions or trade-offs -->

N/A