### PR TITLE
Fix: update CNAME for Storybook deployment URLs

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -38,7 +38,7 @@ jobs:
           publish_dir: storybook-static
           destination_dir: .
           keep_files: true
-
+          cname: ses-react-storybook.registrucentras.lt
       - name: Deploy preview from branch
         if: github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@v4
@@ -47,9 +47,9 @@ jobs:
           publish_dir: storybook-static
           destination_dir: preview/${{ github.ref_name }}
           keep_files: true
-
+          cname: ses-react-storybook.registrucentras.lt
       - name: Storybook preview URL
         if: github.event_name == 'workflow_dispatch'
         run: |
           echo "### Storybook Preview" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 https://registrucentras.github.io/rc-ses-react-components/preview/${{ github.ref_name }}/" >> $GITHUB_STEP_SUMMARY
+          echo "🔗 https://ses-react-storybook.registrucentras.lt/preview/${{ github.ref_name }}/" >> $GITHUB_STEP_SUMMARY

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@registrucentras/rc-ses-react-components",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "dependencies": {
         "@fontsource/public-sans": "^5.0.18",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
   "author": "VĮ REGISTRŲ CENTRAS",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "RC SES React komponentų biblioteka",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## 🔗 Task

[SAV-5264](https://jira.registrucentras.lt/jira/browse/SAV-5264)

## 🧾 Summary

Add custom domain support for Storybook deployed to GitHub Pages.

- Added `cname: ses-react-storybook.registrucentras.lt` to both deploy steps in the workflow so the `CNAME` file is preserved on every deployment
- Updated Storybook preview URL in workflow summary to use the custom domain

## 📸 Screenshots

<!-- Visual proof of changes -->

## ✅ Checklist

* [ ] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

- If the `CNAME` file is missing from the `gh-pages` branch before the first deployment after this merge, HTTPS will temporarily not work until the workflow runs and restores it.