### PR TITLE
SAV-5385: update ServiceHeader component

### DIFF
--- a/src/components/common/Breadcrumbs/index.tsx
+++ b/src/components/common/Breadcrumbs/index.tsx
@@ -1,14 +1,15 @@
-import { Link, Breadcrumbs as MuiBreadcrumbs } from '@mui/material'
+import { Link, Breadcrumbs as MuiBreadcrumbs, SxProps, Theme } from '@mui/material'
 
 export type BreadcrumbItem = { label: string; path: string }
 
 type Props = {
   path: BreadcrumbItem[]
+  sx?: SxProps<Theme>
 }
 
-function RcSesBreadcrumbs({ path }: Props) {
+function RcSesBreadcrumbs({ path, sx }: Props) {
   return (
-    <MuiBreadcrumbs>
+    <MuiBreadcrumbs sx={sx}>
       {path.map((step) => (
         <Link key={step.path} underline='hover' color='inherit' href={step.path}>
           {step.label}

--- a/src/components/layout/ServiceHeader.tsx
+++ b/src/components/layout/ServiceHeader.tsx
@@ -9,10 +9,18 @@ type Props = {
   breadcrumbsProps: React.ComponentProps<typeof RcSesBreadcrumbs>
   children?: React.ReactNode
   title: string
+  backgroundColor?: 'primary' | 'white'
 }
-function ServiceHeader({ breadcrumbsProps, children, title }: Props) {
+function ServiceHeader({
+  breadcrumbsProps,
+  children,
+  title,
+  backgroundColor = 'primary',
+}: Props) {
+  const bgColor = backgroundColor === 'white' ? Colors.grey['0'] : Colors.primary['50']
+
   return (
-    <Box sx={{ backgroundColor: Colors.primary['50'] }}>
+    <Box sx={{ backgroundColor: bgColor }}>
       <Container
         sx={{
           pb: { xs: '2rem', md: '2.25rem' },
@@ -23,14 +31,20 @@ function ServiceHeader({ breadcrumbsProps, children, title }: Props) {
           flexDirection: 'column',
         }}
       >
-        <Box sx={{ mb: { xs: '.875rem', md: '.375rem' } }}>
-          <RcSesBreadcrumbs {...breadcrumbsProps} />
+        <Box>
+          <RcSesBreadcrumbs
+            {...breadcrumbsProps}
+            sx={{
+              fontSize: '0.75rem',
+              lineHeight: '1.25rem',
+            }}
+          />
         </Box>
 
         <Typography
           variant='h1'
           sx={{
-            lineHeight: { xs: '2rem', md: '2.125rem' },
+            lineHeight: { xs: '2rem', md: '2.5rem' },
           }}
         >
           {title}
@@ -45,7 +59,8 @@ function ServiceHeader({ breadcrumbsProps, children, title }: Props) {
               rowGap: '10px',
 
               '.MuiTypography-body1': {
-                lineHeight: '1.3125rem',
+                fontSize: '1rem',
+                lineHeight: '1.5rem',
 
                 [theme.breakpoints.down('md')]: {
                   fontSize: '.8125rem',

--- a/src/components/layout/ServiceHeader.tsx
+++ b/src/components/layout/ServiceHeader.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import RcSesBreadcrumbs from '@/components/common/Breadcrumbs'
 import theme from '@/theme/light'
-import Colors from '@/theme/palette'
+import Colors, { common } from '@/theme/palette'
 
 type Props = {
   breadcrumbsProps: React.ComponentProps<typeof RcSesBreadcrumbs>
@@ -17,7 +17,7 @@ function ServiceHeader({
   title,
   backgroundColor = 'primary',
 }: Props) {
-  const bgColor = backgroundColor === 'white' ? Colors.common.white : Colors.primary['50']
+  const bgColor = backgroundColor === 'white' ? common.white : Colors.primary['50']
 
   return (
     <Box sx={{ backgroundColor: bgColor }}>

--- a/src/components/layout/ServiceHeader.tsx
+++ b/src/components/layout/ServiceHeader.tsx
@@ -34,6 +34,7 @@ function ServiceHeader({
         <RcSesBreadcrumbs
           {...breadcrumbsProps}
           sx={{
+            pb: { xs: '.25rem', md: '.5rem' },
             fontSize: '0.75rem',
             lineHeight: '1.25rem',
           }}

--- a/src/components/layout/ServiceHeader.tsx
+++ b/src/components/layout/ServiceHeader.tsx
@@ -17,7 +17,7 @@ function ServiceHeader({
   title,
   backgroundColor = 'primary',
 }: Props) {
-  const bgColor = backgroundColor === 'white' ? Colors.grey['0'] : Colors.primary['50']
+  const bgColor = backgroundColor === 'white' ? Colors.common.white : Colors.primary['50']
 
   return (
     <Box sx={{ backgroundColor: bgColor }}>
@@ -31,15 +31,13 @@ function ServiceHeader({
           flexDirection: 'column',
         }}
       >
-        <Box>
-          <RcSesBreadcrumbs
-            {...breadcrumbsProps}
-            sx={{
-              fontSize: '0.75rem',
-              lineHeight: '1.25rem',
-            }}
-          />
-        </Box>
+        <RcSesBreadcrumbs
+          {...breadcrumbsProps}
+          sx={{
+            fontSize: '0.75rem',
+            lineHeight: '1.25rem',
+          }}
+        />
 
         <Typography
           variant='h1'

--- a/src/stories/components/layout/ServiceHeader.stories.tsx
+++ b/src/stories/components/layout/ServiceHeader.stories.tsx
@@ -10,26 +10,58 @@ const meta: Meta<typeof RcSesServiceHeader> = {
   argTypes: {
     title: { control: 'text' },
     children: { control: 'text' },
+    backgroundColor: {
+      control: 'inline-radio',
+      options: ['primary', 'white'],
+      table: {
+        defaultValue: { summary: 'primary' },
+      },
+    },
   },
 }
 
 export default meta
 type Story = StoryObj<typeof meta>
 
+const breadcrumbs = {
+  path: [
+    { label: 'Home', path: '/' },
+    { label: 'Services', path: '/services' },
+    { label: 'Service Title', path: '/services/service' },
+  ],
+}
+
 export const Default: Story = {
   args: {
     title: 'Service Title',
     children: 'This is a description of the service.',
-    breadcrumbsProps: {
-      path: [
-        { label: 'Home', path: '/' },
-        { label: 'Services', path: '/services' },
-        { label: 'Service Title', path: '/services/service' },
-      ],
-    },
+    breadcrumbsProps: breadcrumbs,
+    backgroundColor: 'primary',
   },
   render: (args) => (
-    <RcSesServiceHeader title={args.title} breadcrumbsProps={args.breadcrumbsProps}>
+    <RcSesServiceHeader
+      title={args.title}
+      breadcrumbsProps={args.breadcrumbsProps}
+      backgroundColor={args.backgroundColor as any}
+    >
+      {args.children && <Typography variant='body1'>{args.children}</Typography>}
+    </RcSesServiceHeader>
+  ),
+}
+
+export const WhiteBackground: Story = {
+  args: {
+    title: 'Service Title',
+    children: 'This is a description of the service.',
+    breadcrumbsProps: breadcrumbs,
+    backgroundColor: 'white',
+  },
+  render: (args) => (
+    <RcSesServiceHeader
+      title={args.title}
+      breadcrumbsProps={args.breadcrumbsProps}
+      backgroundColor={args.backgroundColor as any}
+    >
       {args.children && <Typography variant='body1'>{args.children}</Typography>}
     </RcSesServiceHeader>
   ),

--- a/src/stories/components/layout/ServiceHeader.stories.tsx
+++ b/src/stories/components/layout/ServiceHeader.stories.tsx
@@ -1,7 +1,10 @@
 import Typography from '@mui/material/Typography'
 import { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
 
 import RcSesServiceHeader from '@/components/layout/ServiceHeader'
+
+type ServiceHeaderProps = React.ComponentProps<typeof RcSesServiceHeader>
 
 const meta: Meta<typeof RcSesServiceHeader> = {
   title: 'components/layout/ServiceHeader',
@@ -42,7 +45,7 @@ export const Default: Story = {
     <RcSesServiceHeader
       title={args.title}
       breadcrumbsProps={args.breadcrumbsProps}
-      backgroundColor={args.backgroundColor as any}
+      backgroundColor={args.backgroundColor as ServiceHeaderProps['backgroundColor']}
     >
       {args.children && <Typography variant='body1'>{args.children}</Typography>}
     </RcSesServiceHeader>
@@ -60,7 +63,7 @@ export const WhiteBackground: Story = {
     <RcSesServiceHeader
       title={args.title}
       breadcrumbsProps={args.breadcrumbsProps}
-      backgroundColor={args.backgroundColor as any}
+      backgroundColor={args.backgroundColor as ServiceHeaderProps['backgroundColor']}
     >
       {args.children && <Typography variant='body1'>{args.children}</Typography>}
     </RcSesServiceHeader>

--- a/src/theme/light/themePalette.tsx
+++ b/src/theme/light/themePalette.tsx
@@ -16,9 +16,6 @@ const themePalette = createTheme({
     dark: grey,
     light: grey,
     ghost: grey,
-    common: {
-      white: '#ffffff',
-    },
   },
   typography: {
     fontFamily: 'Public sans, sans-serif, Arial',

--- a/src/theme/light/themePalette.tsx
+++ b/src/theme/light/themePalette.tsx
@@ -16,6 +16,9 @@ const themePalette = createTheme({
     dark: grey,
     light: grey,
     ghost: grey,
+    common: {
+      white: '#ffffff',
+    },
   },
   typography: {
     fontFamily: 'Public sans, sans-serif, Arial',

--- a/src/theme/palette.tsx
+++ b/src/theme/palette.tsx
@@ -29,6 +29,7 @@ const secondary = {
 }
 
 const grey = {
+  '0': '#ffffff',
   '50': '#f9fafb',
   '100': '#f0f2f5',
   '200': '#dce0e5',

--- a/src/theme/palette.tsx
+++ b/src/theme/palette.tsx
@@ -29,7 +29,6 @@ const secondary = {
 }
 
 const grey = {
-  '0': '#ffffff',
   '50': '#f9fafb',
   '100': '#f0f2f5',
   '200': '#dce0e5',
@@ -80,5 +79,9 @@ const overlays = {
   main: '#ffffff14',
 }
 
-export { primary, secondary, grey, warning, error, overlays }
-export default { primary, secondary, grey, warning, error }
+const common = {
+  white: '#ffffff',
+}
+
+export { primary, secondary, grey, warning, error, overlays, common }
+export default { primary, secondary, grey, warning, error, common }

--- a/src/theme/palette.tsx
+++ b/src/theme/palette.tsx
@@ -84,4 +84,4 @@ const common = {
 }
 
 export { primary, secondary, grey, warning, error, overlays, common }
-export default { primary, secondary, grey, warning, error, common }
+export default { primary, secondary, grey, warning, error }


### PR DESCRIPTION
## 🔗 Task

Contributes to https://jira.registrucentras.lt/jira/browse/SAV-5385

## 🧾 Summary

Changes in this PR:

1. Added a new `backgroundColor` prop for the `ServiceHeader` component to change bg color to `white` (default - `primary`)
2. Some font size changes
3. Added 2 `ServiceHeader` stories showing `white` and `primary` background examples

<!-- Brief explanation of what this PR does and why -->

## 📸 Screenshots

<img width="815" height="553" alt="bg" src="https://github.com/user-attachments/assets/a6051f1f-0054-4d24-87b7-063dbf4c3973" />

<img width="799" height="530" alt="Screenshot 2026-05-12 170046" src="https://github.com/user-attachments/assets/e66dca74-3e19-432e-a041-e2ec6b978866" />

<!-- Visual proof of changes -->

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [x] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

N/A
<!-- Potential regressions or trade-offs -->
