### PR TITLE
Fix Storybook "preview hooks" error on first interaction

### DIFF
--- a/src/stories/components/display/Card.stories.tsx
+++ b/src/stories/components/display/Card.stories.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable react/function-component-definition */
 import { Box, Typography } from '@mui/material'
-import type { Meta, StoryFn } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 import CaretLeftIcon from '@/assets/icons/CaretLeftIcon'
 import MagnifyingGlassIcon from '@/assets/icons/MagnifyingGlassIcon'
@@ -16,54 +15,58 @@ const meta: Meta<typeof RcSesCard> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesCard> = (args) => <RcSesCard {...args} />
+type Story = StoryObj<typeof RcSesCard>
 
-export const Main = Template.bind({})
-Main.args = {
-  title: 'Pavadinimas',
-  description: 'Papildomas aprasymo tekstas',
-  children: (
-    <Box
-      sx={{
-        alignItems: 'center',
-        color: 'text.primary',
-        display: 'flex',
-        justifyContent: 'center',
-        minHeight: { xs: '9.625rem', md: '11.5rem' },
-        px: 3,
-        width: '100%',
-      }}
-    >
-      <Typography align='center'>Vidinis paslaugu front-end sprendimas</Typography>
-    </Box>
-  ),
-  leadingActions: (
-    <RcSesButton startIcon={<CaretLeftIcon />} color='grey' variant='outlined'>
-      Button
-    </RcSesButton>
-  ),
-  trailingActions: (
-    <>
-      <RcSesButton color='grey' variant='outlined'>
+export const Main: Story = {
+  args: {
+    title: 'Pavadinimas',
+    description: 'Papildomas aprasymo tekstas',
+    children: (
+      <Box
+        sx={{
+          alignItems: 'center',
+          color: 'text.primary',
+          display: 'flex',
+          justifyContent: 'center',
+          minHeight: { xs: '9.625rem', md: '11.5rem' },
+          px: 3,
+          width: '100%',
+        }}
+      >
+        <Typography align='center'>Vidinis paslaugu front-end sprendimas</Typography>
+      </Box>
+    ),
+    leadingActions: (
+      <RcSesButton startIcon={<CaretLeftIcon />} color='grey' variant='outlined'>
         Button
       </RcSesButton>
-      <RcSesButton>Button</RcSesButton>
-    </>
-  ),
+    ),
+    trailingActions: (
+      <>
+        <RcSesButton color='grey' variant='outlined'>
+          Button
+        </RcSesButton>
+        <RcSesButton>Button</RcSesButton>
+      </>
+    ),
+  },
 }
 
-export const WithImage = Template.bind({})
-WithImage.args = {
-  variant: 'elevation',
-  centered: true,
-  title: 'Place heading text here',
-  description:
-    'Additional description text elaborating on situation and what to do next.',
-  image: (
-    <Box sx={{ color: palette.grey[400], position: 'relative', display: 'inline-flex' }}>
-      <MagnifyingGlassIcon size={64} fillColor={palette.grey[400]} />
-    </Box>
-  ),
-  children: <RcSesButton>Button</RcSesButton>,
-  contentBackground: false,
+export const WithImage: Story = {
+  args: {
+    variant: 'elevation',
+    centered: true,
+    title: 'Place heading text here',
+    description:
+      'Additional description text elaborating on situation and what to do next.',
+    image: (
+      <Box
+        sx={{ color: palette.grey[400], position: 'relative', display: 'inline-flex' }}
+      >
+        <MagnifyingGlassIcon size={64} fillColor={palette.grey[400]} />
+      </Box>
+    ),
+    children: <RcSesButton>Button</RcSesButton>,
+    contentBackground: false,
+  },
 }

--- a/src/stories/components/display/ImageCard.stories.tsx
+++ b/src/stories/components/display/ImageCard.stories.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable react/function-component-definition */
 import { Box } from '@mui/material'
-import type { Meta, StoryFn } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 import MagnifyingGlassIcon from '@/assets/icons/MagnifyingGlassIcon'
 import RcSesButton from '@/components/common/Button'
@@ -15,7 +14,7 @@ const meta: Meta<typeof RcSesImageCard> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesImageCard> = (args) => <RcSesImageCard {...args} />
+type Story = StoryObj<typeof RcSesImageCard>
 
 const defaultImage = (
   <Box sx={{ position: 'relative', display: 'inline-flex' }}>
@@ -23,32 +22,35 @@ const defaultImage = (
   </Box>
 )
 
-export const Main = Template.bind({})
-Main.args = {
-  image: defaultImage,
-  title: 'Place heading text here',
-  description:
-    'Additional description text elaborating on situation and what to do next.',
-  button: <RcSesButton>Button</RcSesButton>,
+export const Main: Story = {
+  args: {
+    image: defaultImage,
+    title: 'Place heading text here',
+    description:
+      'Additional description text elaborating on situation and what to do next.',
+    button: <RcSesButton>Button</RcSesButton>,
+  },
 }
 
-export const WithoutButton = Template.bind({})
-WithoutButton.args = {
-  image: defaultImage,
-  title: 'Place heading text here',
-  description:
-    'Additional description text elaborating on situation and what to do next.',
+export const WithoutButton: Story = {
+  args: {
+    image: defaultImage,
+    title: 'Place heading text here',
+    description:
+      'Additional description text elaborating on situation and what to do next.',
+  },
 }
 
-export const OutlinedButton = Template.bind({})
-OutlinedButton.args = {
-  image: defaultImage,
-  title: 'Place heading text here',
-  description:
-    'Additional description text elaborating on situation and what to do next.',
-  button: (
-    <RcSesButton color='grey' variant='outlined'>
-      Button
-    </RcSesButton>
-  ),
+export const OutlinedButton: Story = {
+  args: {
+    image: defaultImage,
+    title: 'Place heading text here',
+    description:
+      'Additional description text elaborating on situation and what to do next.',
+    button: (
+      <RcSesButton color='grey' variant='outlined'>
+        Button
+      </RcSesButton>
+    ),
+  },
 }

--- a/src/stories/components/feedback/Alert.stories.tsx
+++ b/src/stories/components/feedback/Alert.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryFn } from '@storybook/react'
+import { Meta, StoryObj } from '@storybook/react'
 
 import RcSesAlert from '@/components/common/Alert'
 import FieldPreview from '@/components/storybook/FieldPreview'
@@ -20,37 +19,39 @@ const meta: Meta<typeof RcSesAlert> = {
 
 export default meta
 
+type Story = StoryObj<typeof RcSesAlert>
+
 // ---------------------------------------------------------------------------
 // Main (interactive / configurable via Controls panel)
 // ---------------------------------------------------------------------------
 
-const Template: StoryFn<typeof RcSesAlert> = (args) => (
-  <Fields>
-    <FieldView>
-      <RcSesAlert {...args} />
-    </FieldView>
-    <FieldPreview>
-      <PreviewTitle>State previews</PreviewTitle>
-      {severities.map((severity) => (
-        <RcSesAlert key={severity} severity={severity}>
-          {lorem}
-        </RcSesAlert>
-      ))}
-    </FieldPreview>
-  </Fields>
-)
-
-export const Main = Template.bind({})
-Main.args = {
-  children: lorem,
-  severity: 'info',
+export const Main: Story = {
+  render: (args) => (
+    <Fields>
+      <FieldView>
+        <RcSesAlert {...args} />
+      </FieldView>
+      <FieldPreview>
+        <PreviewTitle>State previews</PreviewTitle>
+        {severities.map((severity) => (
+          <RcSesAlert key={severity} severity={severity}>
+            {lorem}
+          </RcSesAlert>
+        ))}
+      </FieldPreview>
+    </Fields>
+  ),
+  args: {
+    children: lorem,
+    severity: 'info',
+  },
 }
 
 // ---------------------------------------------------------------------------
 // Variants
 // ---------------------------------------------------------------------------
 
-const VariantsTemplate: StoryFn<typeof RcSesAlert> = (args) => (
+const renderVariants: Story['render'] = (args) => (
   <>
     {severities.map((severity) => (
       <RcSesAlert key={severity} {...args} severity={severity}>
@@ -60,38 +61,46 @@ const VariantsTemplate: StoryFn<typeof RcSesAlert> = (args) => (
   </>
 )
 
-export const Outlined = VariantsTemplate.bind({})
-Outlined.args = { variant: 'outlined' }
+export const Outlined: Story = {
+  render: renderVariants,
+  args: { variant: 'outlined' },
+}
 
-export const Filled = VariantsTemplate.bind({})
-Filled.args = { variant: 'filled' }
+export const Filled: Story = {
+  render: renderVariants,
+  args: { variant: 'filled' },
+}
 
-export const Standard = VariantsTemplate.bind({})
-Standard.args = { variant: 'standard' }
+export const Standard: Story = {
+  render: renderVariants,
+  args: { variant: 'standard' },
+}
 
 // ---------------------------------------------------------------------------
 // Container — full-bleed banner keeping content width-constrained
 // ---------------------------------------------------------------------------
 
-export const WithContainer: StoryFn<typeof RcSesAlert> = () => (
-  <>
-    <PreviewTitle>container (default maxWidth)</PreviewTitle>
-    {severities.map((severity) => (
-      <RcSesAlert key={severity} severity={severity} container sx={{ mb: 1 }}>
-        {lorem}
-      </RcSesAlert>
-    ))}
+export const WithContainer: Story = {
+  render: () => (
+    <>
+      <PreviewTitle>container (default maxWidth)</PreviewTitle>
+      {severities.map((severity) => (
+        <RcSesAlert key={severity} severity={severity} container sx={{ mb: 1 }}>
+          {lorem}
+        </RcSesAlert>
+      ))}
 
-    <PreviewTitle>container with maxWidth=&quot;sm&quot;</PreviewTitle>
-    {severities.map((severity) => (
-      <RcSesAlert
-        key={severity}
-        severity={severity}
-        container={{ maxWidth: 'sm' }}
-        sx={{ mb: 1 }}
-      >
-        {lorem}
-      </RcSesAlert>
-    ))}
-  </>
-)
+      <PreviewTitle>container with maxWidth=&quot;sm&quot;</PreviewTitle>
+      {severities.map((severity) => (
+        <RcSesAlert
+          key={severity}
+          severity={severity}
+          container={{ maxWidth: 'sm' }}
+          sx={{ mb: 1 }}
+        >
+          {lorem}
+        </RcSesAlert>
+      ))}
+    </>
+  ),
+}

--- a/src/stories/components/form/CardFormContainer.stories.tsx
+++ b/src/stories/components/form/CardFormContainer.stories.tsx
@@ -1,6 +1,6 @@
 import { Button, Container, Typography } from '@mui/material'
-import type { Meta, StoryFn } from '@storybook/react'
-import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { ComponentProps, useState } from 'react'
 
 import RcSesCardFormContainer from '@/components/layout/ServiceFormContainer/CardFormContainer'
 import { StepItem } from '@/components/layout/ServiceWizardStepper/StepperTypes'
@@ -57,69 +57,83 @@ const DemoContent = () => (
   </>
 )
 
-const createTemplate =
-  (
-    steps: StepItem[],
-    forcedLayout?: 'row' | 'column',
-  ): StoryFn<typeof RcSesCardFormContainer> =>
-  (args) => {
-    const [activeStep, setActiveStep] = useState(0)
+type Story = StoryObj<typeof RcSesCardFormContainer>
 
-    const handleBack = () => {
-      setActiveStep((prev) => Math.max(prev - 1, 0))
-    }
-
-    const handleNext = () => {
-      setActiveStep((prev) => Math.min(prev + 1, steps.length - 1))
-    }
-
-    const handleStepClick = (index: number) => {
-      if (index > activeStep) return
-      setActiveStep(index)
-    }
-
-    return (
-      <Fields>
-        <FieldView>
-          <RcSesCardFormContainer
-            {...args}
-            layout={forcedLayout}
-            steps={steps}
-            activeStep={activeStep}
-            onStepClick={handleStepClick}
-            leadingActions={
-              <Button onClick={handleBack} disabled={activeStep === 0}>
-                Back
-              </Button>
-            }
-            trailingActions={
-              <>
-                <Button variant='outlined'>Button</Button>
-                <Button
-                  variant='contained'
-                  onClick={handleNext}
-                  disabled={activeStep === steps.length - 1}
-                >
-                  Next
-                </Button>
-              </>
-            }
-          >
-            <DemoContent />
-          </RcSesCardFormContainer>
-        </FieldView>
-      </Fields>
-    )
-  }
-
-export const HorizontalDemo = createTemplate(shortSteps, 'column')
-HorizontalDemo.args = {
-  title: 'Antraštės tekstas',
-  description: 'Papildomas aprašymo tekstas',
+type CardFormContainerDemoProps = ComponentProps<typeof RcSesCardFormContainer> & {
+  steps: StepItem[]
+  forcedLayout?: 'row' | 'column'
 }
 
-export const VerticalDemo = createTemplate(longSteps, 'row')
-VerticalDemo.args = {
-  title: 'Antraštės tekstas',
-  description: 'Papildomas aprašymo tekstas',
+function CardFormContainerDemo({
+  steps,
+  forcedLayout,
+  ...args
+}: CardFormContainerDemoProps) {
+  const [activeStep, setActiveStep] = useState(0)
+
+  const handleBack = () => {
+    setActiveStep((prev) => Math.max(prev - 1, 0))
+  }
+
+  const handleNext = () => {
+    setActiveStep((prev) => Math.min(prev + 1, steps.length - 1))
+  }
+
+  const handleStepClick = (index: number) => {
+    if (index > activeStep) return
+    setActiveStep(index)
+  }
+
+  return (
+    <Fields>
+      <FieldView>
+        <RcSesCardFormContainer
+          {...args}
+          layout={forcedLayout}
+          steps={steps}
+          activeStep={activeStep}
+          onStepClick={handleStepClick}
+          leadingActions={
+            <Button onClick={handleBack} disabled={activeStep === 0}>
+              Back
+            </Button>
+          }
+          trailingActions={
+            <>
+              <Button variant='outlined'>Button</Button>
+              <Button
+                variant='contained'
+                onClick={handleNext}
+                disabled={activeStep === steps.length - 1}
+              >
+                Next
+              </Button>
+            </>
+          }
+        >
+          <DemoContent />
+        </RcSesCardFormContainer>
+      </FieldView>
+    </Fields>
+  )
+}
+
+export const HorizontalDemo: Story = {
+  render: (args) => (
+    <CardFormContainerDemo {...args} steps={shortSteps} forcedLayout='column' />
+  ),
+  args: {
+    title: 'Antraštės tekstas',
+    description: 'Papildomas aprašymo tekstas',
+  },
+}
+
+export const VerticalDemo: Story = {
+  render: (args) => (
+    <CardFormContainerDemo {...args} steps={longSteps} forcedLayout='row' />
+  ),
+  args: {
+    title: 'Antraštės tekstas',
+    description: 'Papildomas aprašymo tekstas',
+  },
 }

--- a/src/stories/components/form/CheckboxFormControl.stories.tsx
+++ b/src/stories/components/form/CheckboxFormControl.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryContext, StoryObj } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
 import RcSesCheckboxFormControl from '@/components/form/inputs/CheckboxFormControl'
@@ -19,61 +18,17 @@ const meta: Meta<typeof RcSesCheckboxFormControl> = {
         defaultValue: { summary: 'outlined' },
       },
     },
-    slotProps: {
-      table: {
-        disable: true,
-      },
-    },
-    loading: {
-      table: {
-        disable: true,
-      },
-    },
-    id: {
-      table: {
-        disable: true,
-      },
-    },
-    errors: {
-      table: {
-        disable: true,
-      },
-    },
-    onBlur: {
-      table: {
-        disable: true,
-      },
-    },
-    onChange: {
-      table: {
-        disable: true,
-      },
-    },
-    rules: {
-      table: {
-        disable: true,
-      },
-    },
-    control: {
-      table: {
-        disable: true,
-      },
-    },
-    name: {
-      table: {
-        disable: true,
-      },
-    },
-    disabled: {
-      table: {
-        disable: true,
-      },
-    },
-    label: {
-      table: {
-        disable: true,
-      },
-    },
+    slotProps: { table: { disable: true } },
+    loading: { table: { disable: true } },
+    id: { table: { disable: true } },
+    errors: { table: { disable: true } },
+    onBlur: { table: { disable: true } },
+    onChange: { table: { disable: true } },
+    rules: { table: { disable: true } },
+    control: { table: { disable: true } },
+    name: { table: { disable: true } },
+    disabled: { table: { disable: true } },
+    label: { table: { disable: true } },
   },
   tags: ['autodocs'],
 }
@@ -84,7 +39,9 @@ type FormModel = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesCheckboxFormControl> = (args) => {
+type Story = StoryObj<typeof RcSesCheckboxFormControl>
+
+function CheckboxFormControlDemo(args: any) {
   const { variant, children } = args
   const {
     control,
@@ -142,19 +99,20 @@ const codeBlock = (args: any) => {
   );`
 }
 
-export const Main = Template.bind({})
-Main.args = {
-  label: 'This is label',
-  children: 'This is body',
-  variant: 'outlined',
-}
-
-Main.parameters = {
-  docs: {
-    source: {
-      type: 'dynamic',
-      transform: (code: string, storyContext: StoryContext) =>
-        codeBlock(storyContext.args),
+export const Main: Story = {
+  render: (args) => <CheckboxFormControlDemo {...args} />,
+  args: {
+    label: 'This is label',
+    children: 'This is body',
+    variant: 'outlined',
+  },
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+        transform: (_code: string, storyContext: StoryContext) =>
+          codeBlock(storyContext.args),
+      },
     },
   },
 }

--- a/src/stories/components/form/ServiceFormActions.stories.tsx
+++ b/src/stories/components/form/ServiceFormActions.stories.tsx
@@ -1,7 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryObj } from '@storybook/react'
 
 import RcSesServiceFormActions from '@/components/layout/ServiceFormActions'
 import FieldView from '@/components/storybook/FieldView'
@@ -15,30 +12,30 @@ const meta: Meta<typeof RcSesServiceFormActions> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesServiceFormActions> = (args) => (
-  <Fields>
-    <FieldView>
-      <RcSesServiceFormActions {...args} />
-    </FieldView>
-  </Fields>
-)
+type Story = StoryObj<typeof RcSesServiceFormActions>
 
-const codeBlock = (args: any) => `
+const codeBlock = () => `
   import RcSesServiceFormActions from '@/components/layout/ServiceFormActions'
 
   const MyComponent = () => (
     <RcSesServiceFormActions/>
   );`
 
-export const Main = Template.bind({})
-Main.args = {}
-
-Main.parameters = {
-  docs: {
-    source: {
-      type: 'dynamic',
-      transform: (code: string, storyContext: StoryContext) =>
-        codeBlock(storyContext.args),
+export const Main: Story = {
+  render: (args) => (
+    <Fields>
+      <FieldView>
+        <RcSesServiceFormActions {...args} />
+      </FieldView>
+    </Fields>
+  ),
+  args: {},
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+        transform: () => codeBlock(),
+      },
     },
   },
 }

--- a/src/stories/components/form/ServiceFormContainer.stories.tsx
+++ b/src/stories/components/form/ServiceFormContainer.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryContext } from '@storybook/react'
 
 import RcSesAccordion from '@/components/common/Accordion'
 import useAccordionController from '@/components/common/Accordion/hooks/useAccordionController'

--- a/src/stories/components/icons/Icons.stories.tsx
+++ b/src/stories/components/icons/Icons.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/function-component-definition, react/prop-types */
 import { Box, FormControl, MenuItem, Select, Typography } from '@mui/material'
-import type { Meta, StoryFn } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 import { useMemo, useState } from 'react'
 import type { ReactElement } from 'react'
 
@@ -349,4 +349,8 @@ const GalleryComponent = ({ className, size, fillColor }: StoryArgs) => {
   )
 }
 
-export const Gallery: StoryFn<StoryArgs> = (args) => <GalleryComponent {...args} />
+type Story = StoryObj<StoryArgs>
+
+export const Gallery: Story = {
+  render: (args) => <GalleryComponent {...args} />,
+}

--- a/src/stories/components/inputs/FileDropzone.stories.tsx
+++ b/src/stories/components/inputs/FileDropzone.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryFn } from '@storybook/react'
+import { Meta, StoryObj } from '@storybook/react'
 import { FieldError, useForm } from 'react-hook-form'
 
 import RcSesFileDropzone from '@/components/form/inputs/FileDropzone'
@@ -18,38 +17,20 @@ const meta: Meta<typeof RcSesFileDropzone> = {
   title: 'components/inputs/FileDropzone',
   component: RcSesFileDropzone,
   argTypes: {
-    control: {
-      table: {
-        disable: true,
-      },
-    },
-    errors: {
-      table: {
-        disable: true,
-      },
-    },
-    rules: {
-      table: {
-        disable: true,
-      },
-    },
-    name: {
-      table: {
-        disable: true,
-      },
-    },
-    id: {
-      table: {
-        disable: true,
-      },
-    },
+    control: { table: { disable: true } },
+    errors: { table: { disable: true } },
+    rules: { table: { disable: true } },
+    name: { table: { disable: true } },
+    id: { table: { disable: true } },
   },
   tags: ['autodocs'],
 }
 
 export default meta
 
-const Template: StoryFn<typeof RcSesFileDropzone> = (args) => {
+type Story = StoryObj<typeof RcSesFileDropzone>
+
+function FileDropzoneDemo(args: any) {
   const {
     control,
     formState: { errors },
@@ -106,12 +87,14 @@ const Template: StoryFn<typeof RcSesFileDropzone> = (args) => {
   )
 }
 
-export const Main = Template.bind({})
-Main.args = {
-  label: 'Upload files',
-  slotProps: {
-    wrapper: {
-      labelSubtitle: 'Tinkami formatai: .doc, .docx, .pdf',
+export const Main: Story = {
+  render: (args) => <FileDropzoneDemo {...args} />,
+  args: {
+    label: 'Upload files',
+    slotProps: {
+      wrapper: {
+        labelSubtitle: 'Tinkami formatai: .doc, .docx, .pdf',
+      },
     },
   },
 }

--- a/src/stories/components/inputs/NumberStepper.stories.tsx
+++ b/src/stories/components/inputs/NumberStepper.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryContext, StoryObj } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
 import RcSesNumberStepper from '@/components/form/inputs/NumberStepper'
@@ -18,48 +17,22 @@ const meta: Meta<typeof RcSesNumberStepper> = {
   title: 'components/inputs/NumberStepper',
   component: RcSesNumberStepper,
   argTypes: {
-    id: {
-      table: {
-        disable: true,
-      },
-    },
-    name: {
-      table: {
-        disable: true,
-      },
-    },
-    control: {
-      table: {
-        disable: true,
-      },
-    },
-    errors: {
-      table: {
-        disable: true,
-      },
-    },
-    onChange: {
-      table: {
-        disable: true,
-      },
-    },
-    onBlur: {
-      table: {
-        disable: true,
-      },
-    },
-    rules: {
-      table: {
-        disable: true,
-      },
-    },
+    id: { table: { disable: true } },
+    name: { table: { disable: true } },
+    control: { table: { disable: true } },
+    errors: { table: { disable: true } },
+    onChange: { table: { disable: true } },
+    onBlur: { table: { disable: true } },
+    rules: { table: { disable: true } },
   },
   tags: ['autodocs'],
 }
 
 export default meta
 
-const Template: StoryFn<typeof RcSesNumberStepper> = (args) => {
+type Story = StoryObj<typeof RcSesNumberStepper>
+
+function NumberStepperDemo(args: any) {
   const { control } = useForm<FormModel>({
     mode: 'all',
     defaultValues: { countable: 0, countable2: 0, countable3: 0 },
@@ -113,9 +86,7 @@ const Template: StoryFn<typeof RcSesNumberStepper> = (args) => {
 }
 
 const codeBlock = (args: any) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { label, disabled, min, max, step, displayStepperControls, slotProps, name, id } =
-    args
+  const { label, disabled, min, max, step, name, id } = args
   return `
   import RcSesNumberStepper from '@/components/form/inputs/NumberStepper'
 
@@ -138,25 +109,26 @@ const codeBlock = (args: any) => {
   );`
 }
 
-export const Main = Template.bind({})
-Main.args = {
-  label: 'Label',
-  disabled: false,
-  min: 0,
-  max: 100,
-  step: 1,
-  displayStepperControls: true,
-  slotProps: { wrapper: { labelSubtitle: 'optional' } },
-  id: 'countable',
-  name: 'countable',
-}
-
-Main.parameters = {
-  docs: {
-    source: {
-      type: 'dynamic',
-      transform: (code: string, storyContext: StoryContext) =>
-        codeBlock(storyContext.args),
+export const Main: Story = {
+  render: (args) => <NumberStepperDemo {...args} />,
+  args: {
+    label: 'Label',
+    disabled: false,
+    min: 0,
+    max: 100,
+    step: 1,
+    displayStepperControls: true,
+    slotProps: { wrapper: { labelSubtitle: 'optional' } },
+    id: 'countable',
+    name: 'countable',
+  },
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+        transform: (_code: string, storyContext: StoryContext) =>
+          codeBlock(storyContext.args),
+      },
     },
   },
 }

--- a/src/stories/components/inputs/RadioButtonGroup.stories.tsx
+++ b/src/stories/components/inputs/RadioButtonGroup.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryContext, StoryObj } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
 import RcSesRadioButtonGroup from '@/components/form/inputs/RadioButtonGroup'
@@ -31,7 +30,9 @@ const meta: Meta<typeof RcSesRadioButtonGroup> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesRadioButtonGroup> = (args) => {
+type Story = StoryObj<typeof RcSesRadioButtonGroup>
+
+function RadioButtonGroupDemo(args: any) {
   const {
     control,
     formState: { errors },
@@ -133,23 +134,24 @@ const codeBlock = (args: any) => {
   );`
 }
 
-export const Main = Template.bind({})
-Main.args = {
-  label: 'Label',
-  options: [
-    { label: 'Pick 1', value: 'pick1' },
-    { label: 'Pick 2', value: 'pick2' },
-    { label: 'Pick 3', value: 'pick3' },
-    { label: 'Pick 4', value: 'pick4' },
-  ],
-}
-
-Main.parameters = {
-  docs: {
-    source: {
-      type: 'dynamic',
-      transform: (code: string, storyContext: StoryContext) =>
-        codeBlock(storyContext.args),
+export const Main: Story = {
+  render: (args) => <RadioButtonGroupDemo {...args} />,
+  args: {
+    label: 'Label',
+    options: [
+      { label: 'Pick 1', value: 'pick1' },
+      { label: 'Pick 2', value: 'pick2' },
+      { label: 'Pick 3', value: 'pick3' },
+      { label: 'Pick 4', value: 'pick4' },
+    ],
+  },
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+        transform: (_code: string, storyContext: StoryContext) =>
+          codeBlock(storyContext.args),
+      },
     },
   },
 }

--- a/src/stories/components/inputs/SearchableField.stories.tsx
+++ b/src/stories/components/inputs/SearchableField.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryContext, StoryObj } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
 import RcSesSearchableField from '@/components/form/inputs/SearchableField'
@@ -14,7 +13,9 @@ const meta: Meta<typeof RcSesSearchableField> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesSearchableField> = (args) => {
+type Story = StoryObj<typeof RcSesSearchableField>
+
+function SearchableFieldDemo(args: any) {
   const { label } = args
   const {
     control,
@@ -74,17 +75,18 @@ const codeBlock = (args: any) => {
   );`
 }
 
-export const Main = Template.bind({})
-Main.args = {
-  label: 'This is label',
-}
-
-Main.parameters = {
-  docs: {
-    source: {
-      type: 'dynamic',
-      transform: (code: string, storyContext: StoryContext) =>
-        codeBlock(storyContext.args),
+export const Main: Story = {
+  render: (args) => <SearchableFieldDemo {...args} />,
+  args: {
+    label: 'This is label',
+  },
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+        transform: (_code: string, storyContext: StoryContext) =>
+          codeBlock(storyContext.args),
+      },
     },
   },
 }

--- a/src/stories/components/inputs/Select.stories.tsx
+++ b/src/stories/components/inputs/Select.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryContext, StoryObj } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
 import RcSesSelect from '@/components/form/inputs/Select'
@@ -67,7 +66,9 @@ const meta: Meta<typeof RcSesSelect> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesSelect> = (args) => {
+type Story = StoryObj<typeof RcSesSelect>
+
+function SelectDemo(args: any) {
   const {
     control,
     formState: { errors },
@@ -208,19 +209,20 @@ const codeBlock = (args: any) => {
   );`
 }
 
-export const Main = Template.bind({})
-Main.args = {
-  label: 'Label',
-  disabled: false,
-  slotProps: { wrapper: { labelOnTop: false } },
-}
-
-Main.parameters = {
-  docs: {
-    source: {
-      type: 'dynamic',
-      transform: (code: string, storyContext: StoryContext) =>
-        codeBlock(storyContext.args),
+export const Main: Story = {
+  render: (args) => <SelectDemo {...args} />,
+  args: {
+    label: 'Label',
+    disabled: false,
+    slotProps: { wrapper: { labelOnTop: false } },
+  },
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+        transform: (_code: string, storyContext: StoryContext) =>
+          codeBlock(storyContext.args),
+      },
     },
   },
 }

--- a/src/stories/components/inputs/TextField.stories.tsx
+++ b/src/stories/components/inputs/TextField.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryContext, StoryFn } from '@storybook/react'
+import { Meta, StoryContext, StoryObj } from '@storybook/react'
 
 import RcSesTextField from '@/components/form/inputs/TextField'
 import FieldPreviewRow from '@/components/storybook/FieldPreviewRow'
@@ -15,38 +14,7 @@ const meta: Meta<typeof RcSesTextField> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesTextField> = (args) => (
-  <Fields>
-    <FieldView>
-      <RcSesTextField {...args} />
-    </FieldView>
-
-    <FieldPreviewRow>
-      <PreviewTitle>State previews label on side</PreviewTitle>
-      <RcSesTextField label='Label' />
-      <RcSesTextField
-        errors={{ message: 'Klaidos pranešimas', type: 'required' }}
-        label='Label'
-      />
-      <RcSesTextField disabled label='Label' />
-    </FieldPreviewRow>
-
-    <FieldPreviewRow>
-      <PreviewTitle>State previews label on top</PreviewTitle>
-      <RcSesTextField slotProps={{ wrapper: { labelOnTop: true } }} label='Label' />
-      <RcSesTextField
-        slotProps={{ wrapper: { labelOnTop: true } }}
-        errors={{ message: 'Klaidos pranešimas', type: 'required' }}
-        label='Label'
-      />
-      <RcSesTextField
-        slotProps={{ wrapper: { labelOnTop: true } }}
-        disabled
-        label='Label'
-      />
-    </FieldPreviewRow>
-  </Fields>
-)
+type Story = StoryObj<typeof RcSesTextField>
 
 const codeBlock = (args: any) => {
   const { slotProps, disabled, label } = args
@@ -58,20 +26,52 @@ const codeBlock = (args: any) => {
   );`
 }
 
-export const Main = Template.bind({})
-Main.args = {
-  label: 'label',
-  disabled: false,
-  multiline: true,
-  slotProps: { wrapper: { labelOnTop: false } },
-}
+export const Main: Story = {
+  render: (args) => (
+    <Fields>
+      <FieldView>
+        <RcSesTextField {...args} />
+      </FieldView>
 
-Main.parameters = {
-  docs: {
-    source: {
-      type: 'dynamic',
-      transform: (code: string, storyContext: StoryContext) =>
-        codeBlock(storyContext.args),
+      <FieldPreviewRow>
+        <PreviewTitle>State previews label on side</PreviewTitle>
+        <RcSesTextField label='Label' />
+        <RcSesTextField
+          errors={{ message: 'Klaidos pranešimas', type: 'required' }}
+          label='Label'
+        />
+        <RcSesTextField disabled label='Label' />
+      </FieldPreviewRow>
+
+      <FieldPreviewRow>
+        <PreviewTitle>State previews label on top</PreviewTitle>
+        <RcSesTextField slotProps={{ wrapper: { labelOnTop: true } }} label='Label' />
+        <RcSesTextField
+          slotProps={{ wrapper: { labelOnTop: true } }}
+          errors={{ message: 'Klaidos pranešimas', type: 'required' }}
+          label='Label'
+        />
+        <RcSesTextField
+          slotProps={{ wrapper: { labelOnTop: true } }}
+          disabled
+          label='Label'
+        />
+      </FieldPreviewRow>
+    </Fields>
+  ),
+  args: {
+    label: 'label',
+    disabled: false,
+    multiline: true,
+    slotProps: { wrapper: { labelOnTop: false } },
+  },
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+        transform: (_code: string, storyContext: StoryContext) =>
+          codeBlock(storyContext.args),
+      },
     },
   },
 }

--- a/src/stories/components/layout/Footer.stories.tsx
+++ b/src/stories/components/layout/Footer.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import type { Meta, StoryFn } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 import RcSesFooter from '@/components/layout/Footer'
 
@@ -11,9 +10,10 @@ const meta: Meta<typeof RcSesFooter> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesFooter> = (args) => <RcSesFooter {...args} />
+type Story = StoryObj<typeof RcSesFooter>
 
-export const Main = Template.bind({})
-Main.args = {
-  text: '© Valstybės įmonė Registrų centras. Duomenys apie įmonę kaupiami ir saugomi Juridinių asmenų registre.\nStudentų g. 39, LT-08106 Vilnius | tel. +370 5 268 8262 | el. p. info@registrucentras.lt | įmonės kodas 124110246 | PVM mokėtojo kodas LT241102419',
+export const Main: Story = {
+  args: {
+    text: '© Valstybės įmonė Registrų centras. Duomenys apie įmonę kaupiami ir saugomi Juridinių asmenų registre.\nStudentų g. 39, LT-08106 Vilnius | tel. +370 5 268 8262 | el. p. info@registrucentras.lt | įmonės kodas 124110246 | PVM mokėtojo kodas LT241102419',
+  },
 }

--- a/src/stories/components/navigation/Breadcrumbs.stories.tsx
+++ b/src/stories/components/navigation/Breadcrumbs.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/function-component-definition */
-import { Meta, StoryFn } from '@storybook/react'
+import { Meta, StoryObj } from '@storybook/react'
 
 import RcSesBreadcrumbs from '@/components/common/Breadcrumbs'
 
@@ -22,11 +21,10 @@ const meta: Meta<typeof RcSesBreadcrumbs> = {
 
 export default meta
 
-const Template: StoryFn<typeof RcSesBreadcrumbs> = (args) => (
-  <RcSesBreadcrumbs {...args} />
-)
+type Story = StoryObj<typeof RcSesBreadcrumbs>
 
-export const Main = Template.bind({})
-Main.args = {
-  path: Path,
+export const Main: Story = {
+  args: {
+    path: Path,
+  },
 }

--- a/src/stories/components/navigation/ServiceWizardStepper.stories.tsx
+++ b/src/stories/components/navigation/ServiceWizardStepper.stories.tsx
@@ -27,27 +27,34 @@ export default meta
 
 type Story = StoryObj<typeof ServiceWizardStepper>
 
-const createStory = (orientation: 'horizontal' | 'vertical'): Story => ({
-  render: (args) => {
-    const [activeStep, setActiveStep] = useState(0)
+function ServiceWizardStepperDemo({
+  orientation,
+  ...args
+}: {
+  orientation: 'horizontal' | 'vertical'
+} & Record<string, unknown>) {
+  const [activeStep, setActiveStep] = useState(0)
 
-    const handleStepClick = (index: number) => {
-      if (index > activeStep) return
-      setActiveStep(index)
-    }
+  const handleStepClick = (index: number) => {
+    if (index > activeStep) return
+    setActiveStep(index)
+  }
 
-    return (
-      <ServiceWizardStepper
-        {...args}
-        steps={steps}
-        activeStep={activeStep}
-        onStepClick={handleStepClick}
-        orientation={orientation}
-      />
-    )
-  },
-})
+  return (
+    <ServiceWizardStepper
+      {...args}
+      steps={steps}
+      activeStep={activeStep}
+      onStepClick={handleStepClick}
+      orientation={orientation}
+    />
+  )
+}
 
-export const Horizontal = createStory('horizontal')
+export const Horizontal: Story = {
+  render: (args) => <ServiceWizardStepperDemo {...args} orientation='horizontal' />,
+}
 
-export const Vertical = createStory('vertical')
+export const Vertical: Story = {
+  render: (args) => <ServiceWizardStepperDemo {...args} orientation='vertical' />,
+}


### PR DESCRIPTION
## 🔗 Task

N/A

## 🧾 Summary

Refactored storybook stories to use separate named demo components to fix "Error: Storybook preview hooks can only be called inside decorators and story functions."

## 📸 Screenshots

N/A

## ✅ Checklist

* [v] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

Not identified
