### PR TITLE
Feat/sav 5459 search component (#67)

### DIFF
--- a/src/components/form/inputs/SearchInput/index.test.tsx
+++ b/src/components/form/inputs/SearchInput/index.test.tsx
@@ -1,0 +1,203 @@
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useForm } from 'react-hook-form'
+import { vi } from 'vitest'
+
+import theme from '@/theme/light'
+
+import RcSesSearchInput from './index'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => {},
+  },
+}))
+
+// Fake md breakpoint so the search button is always rendered
+vi.mock('@mui/material', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mui/material')>()
+  return {
+    ...actual,
+    useMediaQuery: () => true,
+  }
+})
+
+type WrapperProps = Partial<React.ComponentProps<typeof RcSesSearchInput>> & {
+  onSearch?: (value: string) => void
+  defaultValue?: string
+}
+
+const TestWrapper = ({
+  defaultValue = '',
+  onSearch = vi.fn(),
+  ...props
+}: WrapperProps) => {
+  const { control } = useForm({ defaultValues: { search: defaultValue } })
+  return (
+    <ThemeProvider theme={theme}>
+      <RcSesSearchInput
+        id='search'
+        name='search'
+        control={control}
+        label='Search'
+        errors={undefined}
+        onSearch={onSearch}
+        {...props}
+      />
+    </ThemeProvider>
+  )
+}
+
+describe('RcSesSearchInput', () => {
+  test('renders the text input', () => {
+    render(<TestWrapper />)
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  test('renders label', () => {
+    render(<TestWrapper label='My label' />)
+    expect(screen.getByText('My label')).toBeInTheDocument()
+  })
+
+  test('does not show clear button when value is empty', () => {
+    render(<TestWrapper />)
+    expect(
+      screen.queryByRole('button', { name: /clearValueAriaLabel/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  test('search button is disabled when input is empty', () => {
+    render(<TestWrapper />)
+    const btn = screen.getByRole('button', { name: /search/i })
+    expect(btn).toBeDisabled()
+  })
+
+  test('search button is not rendered when showSearchButton=false', () => {
+    render(<TestWrapper showSearchButton={false} />)
+    expect(screen.queryByRole('button', { name: /search/i })).not.toBeInTheDocument()
+  })
+
+  describe('handleSearchClick', () => {
+    test('calls onSearch with current value when button is clicked', () => {
+      const onSearch = vi.fn()
+      render(<TestWrapper onSearch={onSearch} defaultValue='hello' />)
+
+      fireEvent.click(screen.getByRole('button', { name: /search/i }))
+
+      expect(onSearch).toHaveBeenCalledWith('hello')
+    })
+
+    test('does not call onSearch when slotProps.searchButton.onClick calls preventDefault', () => {
+      const onSearch = vi.fn()
+
+      render(
+        <TestWrapper
+          onSearch={onSearch}
+          defaultValue='test'
+          slotProps={{
+            searchButton: {
+              onClick: (e) => e.preventDefault(),
+            },
+          }}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /search/i }))
+
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleFieldKeyDown', () => {
+    test('calls onSearch on Enter when search button is hidden', () => {
+      const onSearch = vi.fn()
+      render(<TestWrapper onSearch={onSearch} showSearchButton={false} />)
+
+      const input = screen.getByRole('textbox')
+      fireEvent.change(input, { target: { value: 'query' } })
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+      expect(onSearch).toHaveBeenCalledWith('query')
+    })
+
+    test('does not call onSearch on Enter when value is empty', () => {
+      const onSearch = vi.fn()
+      render(<TestWrapper onSearch={onSearch} showSearchButton={false} />)
+
+      const input = screen.getByRole('textbox')
+      fireEvent.click(input)
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+
+    test('does not call onSearch on Enter when search button is enabled (shouldSearchOnEnter=false)', () => {
+      const onSearch = vi.fn()
+      render(<TestWrapper onSearch={onSearch} defaultValue='hello' />)
+
+      const input = screen.getByRole('textbox')
+      fireEvent.click(input)
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+
+    test('does not call onSearch when slotProps.field.onKeyDown calls preventDefault', () => {
+      const onSearch = vi.fn()
+
+      render(
+        <TestWrapper
+          onSearch={onSearch}
+          showSearchButton={false}
+          slotProps={{
+            field: {
+              onKeyDown: (e) => {
+                if (e.key === 'Enter') e.preventDefault()
+              },
+            },
+          }}
+        />,
+      )
+
+      const input = screen.getByRole('textbox')
+      fireEvent.change(input, { target: { value: 'hi' } })
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+      expect(onSearch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleFieldChange', () => {
+    test('updates field value as user types', () => {
+      render(<TestWrapper />)
+
+      const input = screen.getByRole('textbox')
+      fireEvent.change(input, { target: { value: 'hello' } })
+
+      expect(input).toHaveValue('hello')
+    })
+
+    test('strips non-numeric characters when onlyNumbers=true', () => {
+      render(<TestWrapper onlyNumbers />)
+
+      const input = screen.getByRole('textbox')
+      fireEvent.change(input, { target: { value: 'ab12cd3' } })
+
+      expect(input).toHaveValue('123')
+    })
+
+    test('calls slotProps.field.onChange before updating value', () => {
+      const fieldOnChange = vi.fn()
+
+      render(<TestWrapper slotProps={{ field: { onChange: fieldOnChange } }} />)
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } })
+
+      expect(fieldOnChange).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/form/inputs/SearchInput/index.tsx
+++ b/src/components/form/inputs/SearchInput/index.tsx
@@ -1,0 +1,282 @@
+import { Box, IconButton, useMediaQuery, useTheme } from '@mui/material'
+import InputAdornment from '@mui/material/InputAdornment'
+import type { OutlinedTextFieldProps } from '@mui/material/TextField'
+import TextField from '@mui/material/TextField'
+import React, { useCallback, useMemo, useRef } from 'react'
+import type { UseControllerProps } from 'react-hook-form'
+import { useController } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { v4 as uuidv4 } from 'uuid'
+
+import MagnifyingGlassIcon from '@/assets/icons/MagnifyingGlassIcon'
+import XCircleFillIcon from '@/assets/icons/XCircleFillIcon'
+import RcSesButton from '@/components/common/Button'
+import RcSesFormControlWrapper, {
+  RcSesFormControlWrapperProps,
+} from '@/components/form/components/FormControlWrapper'
+import type { ButtonProps } from '@/types/buttons/ButtonProps'
+
+type TControllerProps = UseControllerProps<any, any>
+type ImmediateControllerProps = 'control' | 'rules' | 'disabled' | 'name'
+
+type TFieldProps = Omit<OutlinedTextFieldProps, 'variant' | 'value' | 'defaultValue'>
+
+type TWrapperProps = RcSesFormControlWrapperProps
+type ImmediateWrapperProps = 'id' | 'label' | 'errors' | 'labelSubtitle'
+type TSearchButtonProps = Partial<ButtonProps>
+
+type Props = Pick<TControllerProps, ImmediateControllerProps> &
+  Pick<TWrapperProps, ImmediateWrapperProps> & {
+    onSearch: (value: string) => void
+    required?: boolean
+    onlyNumbers?: boolean
+    placeholder?: TFieldProps['placeholder']
+    sideLabel?: boolean
+    showSearchButton?: boolean
+    searchButtonLabel?: string
+    slotProps?: {
+      controller?: Partial<Omit<TControllerProps, ImmediateControllerProps>>
+      field?: Partial<TFieldProps>
+      searchButton?: TSearchButtonProps
+      wrapper?: Partial<Omit<TWrapperProps, ImmediateWrapperProps>>
+    }
+  }
+
+const RcSesSearchInput = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+  const [hasSearchAttempted, setHasSearchAttempted] = React.useState(false)
+  const internalInputRef = useRef<HTMLInputElement>(null)
+
+  const setInputRef = useCallback(
+    (el: HTMLInputElement | null) => {
+      ;(internalInputRef as React.MutableRefObject<HTMLInputElement | null>).current = el
+      if (typeof ref === 'function') {
+        ref(el)
+      } else if (ref) {
+        ;(ref as React.MutableRefObject<HTMLInputElement | null>).current = el
+      }
+    },
+    [ref],
+  )
+
+  const { t } = useTranslation('input', { keyPrefix: 'components.RcSesSearchInput' })
+
+  const {
+    control,
+    labelSubtitle,
+    errors,
+    label,
+    onSearch,
+    required,
+    onlyNumbers = false,
+    placeholder,
+    rules,
+    sideLabel = false,
+    showSearchButton = true,
+    searchButtonLabel,
+    slotProps,
+    disabled,
+    name,
+    id: providedId,
+  } = props
+  const {
+    InputProps: slotFieldInputProps,
+    inputProps: slotFieldNativeInputProps,
+    ...restFieldProps
+  } = slotProps?.field ?? {}
+  const id = useMemo(() => providedId ?? uuidv4(), [providedId])
+
+  const hasRequiredRule = rules?.required !== undefined
+  const isRequired = hasRequiredRule ? !!rules?.required : required === true
+  const controllerRules =
+    hasRequiredRule || !isRequired ? rules : { ...(rules ?? {}), required: true }
+
+  const {
+    field: { onBlur, onChange, value },
+  } = useController({
+    control,
+    name,
+    rules: controllerRules,
+    disabled,
+    shouldUnregister: true,
+    ...slotProps?.controller,
+  })
+
+  const currentTheme = useTheme()
+  const upMd = useMediaQuery(currentTheme.breakpoints.up('md'))
+
+  const mergedSearchButtonProps = slotProps?.searchButton ?? {}
+
+  const shouldRenderSearchButton = showSearchButton !== false && upMd
+
+  const mergedWrapperProps = {
+    ...slotProps?.wrapper,
+    labelSubtitle,
+    hideLabel: slotProps?.wrapper?.hideLabel ?? !label,
+    labelOnTop: slotProps?.wrapper?.labelOnTop ?? !sideLabel,
+  }
+
+  const shouldSearchOnEnter =
+    !shouldRenderSearchButton || !!mergedSearchButtonProps.disabled
+
+  const hasSearchValue = `${value ?? ''}`.trim().length > 0
+  const visibleErrors = hasSearchAttempted ? errors : undefined
+
+  const handleSearchClick: NonNullable<ButtonProps['onClick']> = (event) => {
+    setHasSearchAttempted(true)
+    mergedSearchButtonProps.onClick?.(event)
+
+    if (!event.defaultPrevented && hasSearchValue) {
+      onSearch(value ?? '')
+    }
+  }
+
+  const handleFieldKeyDown: NonNullable<TFieldProps['onKeyDown']> = (event) => {
+    slotProps?.field?.onKeyDown?.(event)
+
+    if (!event.defaultPrevented && shouldSearchOnEnter && event.key === 'Enter') {
+      setHasSearchAttempted(true)
+      event.preventDefault()
+
+      if (hasSearchValue) {
+        onSearch(value ?? '')
+      } else {
+        onBlur()
+      }
+    }
+  }
+
+  const handleFieldChange: NonNullable<TFieldProps['onChange']> = (event) => {
+    slotProps?.field?.onChange?.(event)
+
+    if (event.defaultPrevented) {
+      return
+    }
+
+    const nextValue = event.target.value ?? ''
+    const parsedValue = onlyNumbers ? nextValue.replace(/\D+/g, '') : nextValue
+
+    onChange(parsedValue)
+  }
+
+  const mergedNativeInputProps: NonNullable<
+    NonNullable<TFieldProps['InputProps']>['inputProps']
+  > = {
+    ...(slotFieldInputProps?.inputProps ?? {}),
+    ...(slotFieldNativeInputProps ?? {}),
+    ...(onlyNumbers
+      ? {
+          inputMode: 'numeric',
+          pattern: '[0-9]*',
+        }
+      : {}),
+  }
+
+  const mergedTextFieldInputProps: TFieldProps['InputProps'] = {
+    ...slotFieldInputProps,
+    inputProps: mergedNativeInputProps,
+    startAdornment: (
+      <InputAdornment position='start' onClick={() => internalInputRef.current?.focus()}>
+        <Box
+          sx={{
+            alignItems: 'center',
+            cursor: 'text',
+            display: 'flex',
+            height: '2.5rem',
+            justifyContent: 'center',
+            p: 1,
+            width: '2.5rem',
+          }}
+        >
+          <MagnifyingGlassIcon />
+        </Box>
+      </InputAdornment>
+    ),
+    endAdornment: !!value && (
+      <InputAdornment position='end'>
+        <IconButton
+          aria-label={t('clearValueAriaLabel')}
+          disabled={disabled}
+          onClick={() => onChange('')}
+        >
+          <XCircleFillIcon />
+        </IconButton>
+      </InputAdornment>
+    ),
+  }
+
+  return (
+    <RcSesFormControlWrapper
+      id={id}
+      errors={visibleErrors}
+      label={label}
+      required={isRequired}
+      {...mergedWrapperProps}
+    >
+      <Box
+        sx={{
+          alignItems: 'stretch',
+          display: 'flex',
+          gap: 2,
+          width: '100%',
+        }}
+      >
+        <TextField
+          id={id}
+          inputRef={setInputRef}
+          InputProps={mergedTextFieldInputProps}
+          error={!!visibleErrors}
+          fullWidth
+          {...restFieldProps}
+          disabled={disabled}
+          label={undefined}
+          name={name}
+          onBlur={onBlur}
+          onChange={handleFieldChange}
+          onKeyDown={handleFieldKeyDown}
+          placeholder={restFieldProps.placeholder ?? placeholder}
+          sx={[
+            {
+              flex: '1 1 auto',
+              '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus':
+                {
+                  WebkitBoxShadow: `0 0 0 1000px ${currentTheme.palette.background.paper} inset`,
+                },
+              '& .MuiOutlinedInput-root:has(input:-webkit-autofill)': {
+                backgroundColor: currentTheme.palette.background.paper,
+              },
+            },
+            ...(Array.isArray(restFieldProps.sx)
+              ? restFieldProps.sx
+              : [restFieldProps.sx]),
+          ]}
+          value={value ?? ''}
+        />
+
+        {shouldRenderSearchButton && (
+          <RcSesButton
+            disabled={disabled || mergedSearchButtonProps.disabled || !hasSearchValue}
+            onClick={handleSearchClick}
+            sx={[
+              {
+                flexShrink: 0,
+                minWidth: '6.75rem',
+                px: 3,
+                whiteSpace: 'nowrap',
+              },
+              ...(Array.isArray(mergedSearchButtonProps.sx)
+                ? mergedSearchButtonProps.sx
+                : [mergedSearchButtonProps.sx]),
+            ]}
+            {...mergedSearchButtonProps}
+          >
+            {searchButtonLabel ??
+              mergedSearchButtonProps.children ??
+              t('searchButtonLabel')}
+          </RcSesButton>
+        )}
+      </Box>
+    </RcSesFormControlWrapper>
+  )
+})
+
+export default RcSesSearchInput

--- a/src/i18n/namespaces/input/en.json
+++ b/src/i18n/namespaces/input/en.json
@@ -48,6 +48,11 @@
     "RcSesSearchableField": {
       "clearValueAriaLabel": "Clear search value",
       "searchAriaLabel": "Open search"
+    },
+
+    "RcSesSearchInput": {
+      "clearValueAriaLabel": "Clear search value",
+      "searchButtonLabel": "Search"
     }
   }
 }

--- a/src/i18n/namespaces/input/lt.json
+++ b/src/i18n/namespaces/input/lt.json
@@ -48,6 +48,11 @@
     "RcSesSearchableField": {
       "clearValueAriaLabel": "Išvalyti paieškos reikšmę",
       "searchAriaLabel": "Ieškoti"
+    },
+
+    "RcSesSearchInput": {
+      "clearValueAriaLabel": "Išvalyti paieškos reikšmę",
+      "searchButtonLabel": "Ieškoti"
     }
   }
 }

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -28,6 +28,7 @@ import RcSesNumberStepper from '@/components/form/inputs/NumberStepper'
 import RcSesPhoneInput from '@/components/form/inputs/PhoneInput'
 import RcSesPhoneInputFormControl from '@/components/form/inputs/PhoneInputFormControl'
 import RcSesRadioButtonGroup from '@/components/form/inputs/RadioButtonGroup'
+import RcSesSearchInput from '@/components/form/inputs/SearchInput'
 import RcSesSearchableField from '@/components/form/inputs/SearchableField'
 import RcSesSelect from '@/components/form/inputs/Select'
 import RcSesTextField from '@/components/form/inputs/TextField'
@@ -67,6 +68,7 @@ export { RcSesFileDropzone }
 export { RcSesNumberStepper }
 export { RcSesPhoneInput, RcSesPhoneInputFormControl }
 export { RcSesRadioButtonGroup }
+export { RcSesSearchInput }
 export { RcSesSearchableField }
 export { RcSesSelect }
 export { RcSesTab, RcSesTabPanel, RcSesTabs, RcSesTabsWrapper }

--- a/src/stories/components/inputs/SearchInput.stories.tsx
+++ b/src/stories/components/inputs/SearchInput.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import RcSesSearchInput from '@/components/form/inputs/SearchInput'
+import SingleStepFormModel from '@/examples/SingleStepForm/types/SingleStepFormModel'
+
+const meta: Meta<typeof RcSesSearchInput> = {
+  title: 'components/inputs/SearchInput',
+  component: RcSesSearchInput,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+    },
+    labelSubtitle: {
+      control: 'text',
+    },
+    required: {
+      control: 'boolean',
+    },
+    placeholder: {
+      control: 'text',
+    },
+    onlyNumbers: {
+      control: 'boolean',
+    },
+    sideLabel: {
+      control: 'boolean',
+    },
+    showSearchButton: {
+      control: 'boolean',
+    },
+    searchButtonLabel: {
+      control: 'text',
+    },
+    slotProps: {
+      control: 'object',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof RcSesSearchInput>
+
+const StoryTemplate = (args: React.ComponentProps<typeof RcSesSearchInput>) => {
+  const { onSearch, slotProps, ...restArgs } = args
+  const [lastSearchValue, setLastSearchValue] = useState('')
+  const [searchCount, setSearchCount] = useState(0)
+  const {
+    control,
+    formState: { errors },
+  } = useForm<SingleStepFormModel>({
+    mode: 'all',
+  })
+
+  const handleSearch = (value: string) => {
+    const newCount = searchCount + 1
+    setLastSearchValue(value)
+    setSearchCount(newCount)
+    onSearch(value)
+  }
+
+  return (
+    <div>
+      <RcSesSearchInput
+        {...restArgs}
+        control={control}
+        id='searchable'
+        errors={errors?.searchable}
+        name='searchable'
+        onSearch={handleSearch}
+        slotProps={slotProps}
+      />
+      <p style={{ marginTop: 12 }}>
+        Searches: {searchCount} | Last value: {lastSearchValue || '-'}
+      </p>
+    </div>
+  )
+}
+
+export const Main: Story = {
+  args: {
+    label: 'Search Input Field',
+    placeholder: 'Type to search',
+    onSearch: fn(),
+  },
+  render: (args) => <StoryTemplate {...args} />,
+}
+
+export const OnlyRequired: Story = {
+  args: {
+    onSearch: fn(),
+  },
+  render: (args) => <StoryTemplate {...args} />,
+}
+
+export const WithoutButton: Story = {
+  args: {
+    ...Main.args,
+    showSearchButton: false,
+  },
+  render: (args) => <StoryTemplate {...args} />,
+}
+
+export const WithoutLabel: Story = {
+  args: {
+    ...Main.args,
+    label: undefined,
+  },
+  render: (args) => <StoryTemplate {...args} />,
+}
+
+export const SideLabel: Story = {
+  args: {
+    ...Main.args,
+    sideLabel: true,
+  },
+  render: (args) => <StoryTemplate {...args} />,
+}
+
+export const OnlyNumbers: Story = {
+  args: {
+    ...Main.args,
+    onlyNumbers: true,
+    placeholder: 'Only numbers allowed',
+  },
+  render: (args) => <StoryTemplate {...args} />,
+}

--- a/src/theme/light/MuiOutlinedInput.ts
+++ b/src/theme/light/MuiOutlinedInput.ts
@@ -1,0 +1,15 @@
+import { Components } from '@mui/material'
+
+const MuiOutlinedInput: Components['MuiOutlinedInput'] = {
+  styleOverrides: {
+    root: {
+      borderRadius: '.5rem',
+
+      '.MuiOutlinedInput-notchedOutline': {
+        borderRadius: '.5rem',
+      },
+    },
+  },
+}
+
+export default MuiOutlinedInput

--- a/src/theme/light/index.tsx
+++ b/src/theme/light/index.tsx
@@ -26,6 +26,7 @@ import MuiFormLabel from '@/theme/light/MuiFormLabel'
 import MuiIconButton from '@/theme/light/MuiIconButton'
 import MuiInputBase from '@/theme/light/MuiInputBase'
 import MuiLinearProgress from '@/theme/light/MuiLinearProgress'
+import MuiOutlinedInput from '@/theme/light/MuiOutlinedInput'
 import MuiPickersLayout from '@/theme/light/MuiPickersLayout'
 import MuiPopover from '@/theme/light/MuiPopover'
 import MuiRadio from '@/theme/light/MuiRadio'
@@ -108,6 +109,7 @@ const theme = createTheme(themePalette, ltLT, enUS, {
     MuiIconButton,
     MuiInputBase,
     MuiLinearProgress,
+    MuiOutlinedInput,
     MuiPickersLayout,
     MuiPagination,
     MuiPaginationItem,


### PR DESCRIPTION
* fix: add iconOnly prop to RcSesButton and update button styles

* fix: update button styles

* refactor: unify border radius across input components

* feat: add stories for FileDropzone and PhoneInput components

* feat: add RcSesSearchInput component and its stories

* feat: add disabled control to RcSesSearchInput story

* feat: add labelSubtitle prop to RcSesSearchInput and its story

* fix: after review

* feat: enhance RcSesSearchInput with input ref handling and autofill styles

* fix: after review, RcSesSearchInput to use theme for styling and refactor searchButtonProps to slotProps

* tests

* minor fixes