### PR TITLE
SAV-5655: add new Button variants (Light&Ghost)

### DIFF
--- a/src/stories/components/actions/Button.stories.tsx
+++ b/src/stories/components/actions/Button.stories.tsx
@@ -3,6 +3,7 @@ import { fn } from '@storybook/test'
 
 import PlusBoldIcon from '@/assets/icons/PlusBoldIcon'
 import Button from '@/components/common/Button'
+import { grey } from '@/theme/palette'
 import { ButtonProps } from '@/types/buttons/ButtonProps'
 
 const variantOptions: Array<ButtonProps['variant']> = [
@@ -21,6 +22,8 @@ const colorOptions = [
   'success',
   'info',
   'warning',
+  'light',
+  'ghost',
 ]
 
 const meta = {
@@ -233,4 +236,131 @@ export const ErrorOutlined: Story = {
     color: 'error',
     variant: 'outlined',
   },
+}
+
+export const LightOutlined: Story = {
+  args: {
+    variant: 'outlined',
+    color: 'light' as any,
+    children: 'Light Button',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          backgroundColor: grey[900],
+          padding: '0.5rem',
+          borderRadius: '0.5rem',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const LightOutlinedWithIcon: Story = {
+  args: {
+    variant: 'outlined',
+    color: 'light' as any,
+    startIcon: <PlusBoldIcon />,
+    children: 'Light Button with Icon',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          backgroundColor: grey[900],
+          padding: '0.5rem',
+          borderRadius: '0.5rem',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const LightOutlinedDisabled: Story = {
+  args: {
+    variant: 'outlined',
+    color: 'light' as any,
+    children: 'Light Button Disabled',
+    disabled: true,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          backgroundColor: grey[900],
+          padding: '0.5rem',
+          borderRadius: '0.5rem',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const GhostOutlinedIconOnly: Story = {
+  args: {
+    'aria-label': 'Close',
+    children: <PlusBoldIcon />,
+    color: 'ghost' as any,
+    iconOnly: true,
+    variant: 'outlined',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          backgroundColor: grey[900],
+          padding: '0.5rem',
+          borderRadius: '0.5rem',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const GhostOutlinedIconOnlyDisabled: Story = {
+  args: {
+    'aria-label': 'Close',
+    children: <PlusBoldIcon />,
+    color: 'ghost' as any,
+    disabled: true,
+    iconOnly: true,
+    variant: 'outlined',
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          backgroundColor: grey[900],
+          padding: '0.5rem',
+          borderRadius: '0.5rem',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
 }

--- a/src/stories/components/display/SelectableCardList.stories.tsx
+++ b/src/stories/components/display/SelectableCardList.stories.tsx
@@ -52,7 +52,7 @@ const buildItems = (): SelectableCardListItemData[] =>
   }))
 
 const meta = {
-  title: 'components/common/SelectableCardList',
+  title: 'components/display/SelectableCardList',
   component: SelectableCardList,
   tags: ['autodocs'],
   args: {

--- a/src/theme/light/MuiButton.tsx
+++ b/src/theme/light/MuiButton.tsx
@@ -1,6 +1,6 @@
 import { Components } from '@mui/material'
 
-import palette, { error, grey, primary, secondary, warning } from '../palette'
+import palette, { error, grey, overlays, primary, secondary, warning } from '../palette'
 
 const MuiButton: Components['MuiButton'] = {
   variants: [
@@ -355,6 +355,39 @@ const MuiButton: Components['MuiButton'] = {
         },
         '&:active': {
           backgroundColor: error[100],
+        },
+      },
+
+      '&.MuiButton-colorLight': {
+        borderColor: grey[50],
+        color: grey[50],
+        backgroundColor: 'transparent',
+
+        '&:hover': {
+          backgroundColor: overlays['200'],
+        },
+        '&:active': {
+          backgroundColor: overlays['300'],
+        },
+        '&.Mui-disabled': {
+          borderColor: `${grey[500]} !important`,
+          color: `${grey[500]} !important`,
+        },
+      },
+
+      '&.MuiButton-colorGhost': {
+        borderColor: 'transparent',
+        color: grey[50],
+        backgroundColor: 'transparent',
+
+        '&:hover': {
+          backgroundColor: overlays['200'],
+        },
+        '&:active': {
+          backgroundColor: overlays['300'],
+        },
+        '&.Mui-disabled': {
+          borderColor: `transparent !important`,
         },
       },
     },

--- a/src/theme/light/index.tsx
+++ b/src/theme/light/index.tsx
@@ -47,11 +47,15 @@ declare module '@mui/material/styles' {
   interface Palette {
     dark: Palette['grey']
     grey: Palette['grey']
+    light: Palette['grey']
+    ghost: Palette['grey']
   }
 
   interface PaletteOptions {
     dark?: PaletteOptions['grey']
     grey?: PaletteOptions['grey']
+    light?: PaletteOptions['grey']
+    ghost?: PaletteOptions['grey']
   }
 }
 
@@ -73,6 +77,8 @@ declare module '@mui/material' {
   interface ButtonPropsColorOverrides {
     grey: any
     dark: any
+    light: any
+    ghost: any
   }
 
   interface RadioPropsColorOverrides {

--- a/src/theme/light/themePalette.tsx
+++ b/src/theme/light/themePalette.tsx
@@ -14,6 +14,8 @@ const themePalette = createTheme({
     error,
     grey,
     dark: grey,
+    light: grey,
+    ghost: grey,
   },
   typography: {
     fontFamily: 'Public sans, sans-serif, Arial',

--- a/src/theme/palette.tsx
+++ b/src/theme/palette.tsx
@@ -73,5 +73,11 @@ const error = {
   main: '#fa5a46',
 }
 
-export { primary, secondary, grey, warning, error }
+const overlays = {
+  '200': '#ffffff14',
+  '300': '#ffffff29',
+  main: '#ffffff14',
+}
+
+export { primary, secondary, grey, warning, error, overlays }
 export default { primary, secondary, grey, warning, error }


### PR DESCRIPTION
## 🔗 Task

Task https://jira.registrucentras.lt/jira/browse/SAV-5655

🎨 [Figma designs for the Button](https://www.figma.com/design/GPujqQEuxSUKDUPbYmx7TG/RC-Dizaino-sistema?node-id=44625-50678&t=JY9M0diTJW1tXM5t-4)

## 🧾 Summary

✅ Added 2 new Button color variants:
* `color: light` - outlined button
* `color: ghost` - icon-only

✅ Added new overlay tokens:


```
white-8: #ffffff14 (hover)
white-16: #ffffff29 (pressed)
```

✅ Moved `SelectableCardList` to `display` (in stories) - extra

## 📸 Screenshots

It's best to check in the Storybook directly as there's hover, active and other states to test. Some examples:

<img width="181" height="80" alt="Screenshot 2026-05-06 154505" src="https://github.com/user-attachments/assets/cef6b803-a7b1-4058-96cf-e27d69e74188" />


<img width="100" height="93" alt="Screenshot 2026-05-06 154545" src="https://github.com/user-attachments/assets/686d03a0-c662-40c9-8cd5-9bbe1c271d1e" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [x] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

<!-- Potential regressions or trade-offs -->

N/A as this button variant is not used yet (will be used in the Snackbar component).
