### PR TITLE
SAV-5685: add SimpleCheckbox without form wrapper

### DIFF
--- a/src/components/form/inputs/SimpleCheckbox.tsx
+++ b/src/components/form/inputs/SimpleCheckbox.tsx
@@ -3,11 +3,11 @@ import { Checkbox as MuiCheckbox, CheckboxProps as MuiCheckboxProps } from '@mui
 import CheckBoldIcon from '@/assets/icons/CheckBoldIcon'
 import CheckUncheckedBoldIcon from '@/assets/icons/CheckUncheckedBoldIcon'
 
-type Props = MuiCheckboxProps & {
+export type SimpleCheckboxProps = MuiCheckboxProps & {
   loading?: boolean
 }
 
-function RcSesSimpleCheckbox({ loading, ...props }: Props) {
+function RcSesSimpleCheckbox({ loading, ...props }: SimpleCheckboxProps) {
   return (
     <MuiCheckbox
       checkedIcon={loading ? undefined : <CheckBoldIcon />}

--- a/src/components/form/inputs/SimpleCheckbox.tsx
+++ b/src/components/form/inputs/SimpleCheckbox.tsx
@@ -1,0 +1,21 @@
+import { Checkbox as MuiCheckbox, CheckboxProps as MuiCheckboxProps } from '@mui/material'
+
+import CheckBoldIcon from '@/assets/icons/CheckBoldIcon'
+import CheckUncheckedBoldIcon from '@/assets/icons/CheckUncheckedBoldIcon'
+
+type Props = MuiCheckboxProps & {
+  loading?: boolean
+}
+
+function RcSesSimpleCheckbox({ loading, ...props }: Props) {
+  return (
+    <MuiCheckbox
+      checkedIcon={loading ? undefined : <CheckBoldIcon />}
+      icon={loading ? undefined : <CheckUncheckedBoldIcon />}
+      {...props}
+      disableRipple
+    />
+  )
+}
+
+export default RcSesSimpleCheckbox

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -31,6 +31,7 @@ import RcSesRadioButtonGroup from '@/components/form/inputs/RadioButtonGroup'
 import RcSesSearchInput from '@/components/form/inputs/SearchInput'
 import RcSesSearchableField from '@/components/form/inputs/SearchableField'
 import RcSesSelect from '@/components/form/inputs/Select'
+import RcSesSimpleCheckbox from '@/components/form/inputs/SimpleCheckbox'
 import RcSesTextField from '@/components/form/inputs/TextField'
 import RcSesFooter from '@/components/layout/Footer'
 import RcSesServiceFormActions from '@/components/layout/ServiceFormActions'
@@ -61,7 +62,7 @@ export {
   RcSesFooter,
   RcSesImageCard,
 }
-export { RcSesCheckbox, RcSesCheckboxFormControl }
+export { RcSesCheckbox, RcSesCheckboxFormControl, RcSesSimpleCheckbox }
 export { RcSesDatepicker }
 export { RcSesFileUpload }
 export { RcSesFileDropzone }

--- a/src/library/types.ts
+++ b/src/library/types.ts
@@ -1,6 +1,7 @@
 import { RcSesCardProps } from '@/components/common/Card'
 import { ListWithIconsProps } from '@/components/common/ListWithIcons'
 import { ListWithIconsItemData } from '@/components/common/ListWithIcons/ListWithIcons.types'
+import { SimpleCheckboxProps } from '@/components/form/inputs/SimpleCheckbox'
 import { RcSesCardFormContainerProps } from '@/components/layout/ServiceFormContainer/CardFormContainer'
 import { ServiceWizardStepperProps } from '@/components/layout/ServiceWizardStepper'
 import { ButtonProps } from '@/types/buttons/ButtonProps'
@@ -8,4 +9,9 @@ import { ButtonProps } from '@/types/buttons/ButtonProps'
 export type { ListWithIconsProps, ListWithIconsItemData }
 export type { ButtonProps }
 
-export type { RcSesCardFormContainerProps, RcSesCardProps, ServiceWizardStepperProps }
+export type {
+  RcSesCardFormContainerProps,
+  RcSesCardProps,
+  ServiceWizardStepperProps,
+  SimpleCheckboxProps,
+}

--- a/src/stories/components/form/SimpleCheckbox.stories.tsx
+++ b/src/stories/components/form/SimpleCheckbox.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import SimpleCheckbox from '@/components/form/inputs/SimpleCheckbox'
+
+const meta = {
+  title: 'components/inputs/SimpleCheckbox',
+  component: SimpleCheckbox,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Lightweight checkbox without form wrapper. Use as children in CheckboxFormControl or anywhere you need a plain checkbox without form wrapper overhead.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SimpleCheckbox>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function BasicDemo() {
+  const [checked, setChecked] = useState(false)
+  return (
+    <SimpleCheckbox checked={checked} onChange={(e) => setChecked(e.target.checked)} />
+  )
+}
+
+export const Basic: Story = {
+  render: () => <BasicDemo />,
+}


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/SAV-5685

## 🧾 Summary

Added a new `SimpleCheckbox` component to be used in parent-child logic, without form wrapper. Current `RcSesCheckbox` is designed as a standalone component with its own form wrapper which breaks the hierarchy if used in a parent-child logic.

## 📸 Screenshots

<img width="1190" height="359" alt="image" src="https://github.com/user-attachments/assets/ed4384b0-562f-4a67-8e04-5b076f259088" />

<!-- Visual proof of changes -->

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

N/A, because component is not used yet.

<!-- Potential regressions or trade-offs -->
