### PR TITLE
feat: add loading state with spinner (ArrowsClockwiseIcon) to Button

### DIFF
--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,5 +1,6 @@
 import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material'
 
+import ArrowsClockwiseIcon from '@/assets/icons/ArrowsClockwiseIcon'
 import { ButtonProps } from '@/types/buttons/ButtonProps'
 
 const defaultProps: Partial<MuiButtonProps> = {
@@ -14,10 +15,25 @@ const ICON_ONLY_SIZE_MAP = {
   large: '3rem',
 } as const
 
+const SPINNER_SIZE_MAP = {
+  small: 16,
+  medium: 20,
+  large: 24,
+} as const
+
 type Props = ButtonProps & { to?: string }
 
 function RcSesButton(props: Props) {
-  const { children, iconOnly, size = 'medium', sx, variant, ...rest } = props
+  const {
+    children,
+    disabled,
+    iconOnly,
+    loading,
+    size = 'medium',
+    sx,
+    variant,
+    ...rest
+  } = props
 
   const currentVariant = variant ?? defaultProps.variant
   const isIconOnly =
@@ -27,10 +43,36 @@ function RcSesButton(props: Props) {
     <MuiButton
       {...defaultProps}
       {...rest}
+      disabled={disabled || loading}
       size={size}
-      variant={variant}
+      variant={currentVariant}
       sx={[
         ...(Array.isArray(sx) ? sx : [sx]),
+        loading
+          ? {
+              position: 'relative',
+              '& .MuiButton-startIcon, & .MuiButton-endIcon, & .RcSesButton-content': {
+                visibility: 'hidden',
+              },
+              '& .RcSesButton-loading': {
+                alignItems: 'center',
+                display: 'inline-flex',
+                inset: 0,
+                justifyContent: 'center',
+                pointerEvents: 'none',
+                position: 'absolute',
+              },
+              '& .RcSesButton-spinner': {
+                animation: 'RcSesButtonSpin 1s linear infinite',
+                display: 'inline-flex',
+                transformOrigin: 'center',
+              },
+              '@keyframes RcSesButtonSpin': {
+                '0%': { transform: 'rotate(0deg)' },
+                '100%': { transform: 'rotate(360deg)' },
+              },
+            }
+          : undefined,
         isIconOnly
           ? {
               minWidth: 0,
@@ -44,7 +86,14 @@ function RcSesButton(props: Props) {
           : undefined,
       ]}
     >
-      {children}
+      <span className='RcSesButton-content'>{children}</span>
+      {loading ? (
+        <span className='RcSesButton-loading'>
+          <span className='RcSesButton-spinner'>
+            <ArrowsClockwiseIcon size={SPINNER_SIZE_MAP[size]} />
+          </span>
+        </span>
+      ) : null}
     </MuiButton>
   )
 }

--- a/src/stories/components/actions/Button.stories.tsx
+++ b/src/stories/components/actions/Button.stories.tsx
@@ -71,6 +71,14 @@ const meta = {
         defaultValue: {},
       },
     },
+    loading: {
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {},
+      },
+    },
   },
   tags: ['autodocs'],
   args: {
@@ -129,6 +137,36 @@ export const PrimaryContainedWithSuffixIcon: Story = {
   },
 }
 
+export const PrimaryContainedLoading: Story = {
+  args: {
+    variant: 'contained',
+    color: 'primary',
+    loading: true,
+    children: 'Saving',
+  },
+}
+
+export const PrimaryContainedLoadingWithIcon: Story = {
+  args: {
+    variant: 'contained',
+    color: 'primary',
+    loading: true,
+    startIcon: <PlusBoldIcon />,
+    children: 'Add item',
+  },
+}
+
+export const PrimaryContainedIconOnlyLoading: Story = {
+  args: {
+    'aria-label': 'Add',
+    children: <PlusBoldIcon />,
+    color: 'primary',
+    iconOnly: true,
+    loading: true,
+    variant: 'contained',
+  },
+}
+
 export const PrimaryContainedIconOnly: Story = {
   args: {
     'aria-label': 'Add',
@@ -172,6 +210,18 @@ export const PrimaryOutlinedIconOnly: Story = {
     children: <PlusBoldIcon />,
     color: 'primary',
     iconOnly: true,
+    variant: 'outlined',
+  },
+}
+
+export const PrimaryOutlinedIconOnlyLoading: Story = {
+  parameters: disableColorContrast,
+  args: {
+    'aria-label': 'Add',
+    children: <PlusBoldIcon />,
+    color: 'primary',
+    iconOnly: true,
+    loading: true,
     variant: 'outlined',
   },
 }

--- a/src/types/buttons/ButtonProps.tsx
+++ b/src/types/buttons/ButtonProps.tsx
@@ -2,4 +2,5 @@ import { ButtonProps as MuiButtonProps } from '@mui/material'
 
 export type ButtonProps = MuiButtonProps & {
   iconOnly?: boolean
+  loading?: boolean
 }


### PR DESCRIPTION
Loading state to the Button component with a centered spinning icon, while keeping button dimensions stable in all variants.

## 🔗 Task

## 🧾 Summary

1. Added a new loading prop to the Button API.
2. Updated Button behavior so that when loading is true:
- the button becomes disabled,
- existing content (text/icons) is visually hidden without changing layout size,
- a centered spinning ArrowsClockwiseIcon is displayed.
3. Ensured the same behavior works for icon-only buttons.
4. Added Storybook examples for loading scenarios, including:
- text-only loading,
- loading with icon + text,
- icon-only loading.

## 📸 Screenshots

<img width="1025" height="635" alt="image" src="https://github.com/user-attachments/assets/9dc5d81b-d0cf-48d0-925b-58c84a351856" />

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks
