### PR TITLE
SAV-5592: Snackbar UX changes + ServiceHeader bg change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@registrucentras/rc-ses-react-components",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@fontsource/public-sans": "^5.0.18",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
   "author": "VĮ REGISTRŲ CENTRAS",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "RC SES React komponentų biblioteka",
   "type": "module",
   "private": false,

--- a/src/components/common/Snackbar/config.ts
+++ b/src/components/common/Snackbar/config.ts
@@ -15,6 +15,11 @@ export const SNACKBAR_DURATION = 10000 // 10s
 
 export const SNACKBAR_ICON_SIZE = { width: 18, height: 20 }
 
+export const SNACKBAR_CHAR_LIMITS: Record<SnackbarSize, number> = {
+  standard: 120,
+  compact: 60,
+}
+
 export const stateConfig: Record<
   SnackbarState,
   {

--- a/src/components/common/Snackbar/index.tsx
+++ b/src/components/common/Snackbar/index.tsx
@@ -13,7 +13,13 @@ import CloseIcon from '@/assets/icons/CloseIcon'
 import { grey } from '@/theme/palette'
 
 import RcSesButton from '../Button'
-import { SNACKBAR_DURATION, SNACKBAR_ICON_SIZE, sizeConfig, stateConfig } from './config'
+import {
+  SNACKBAR_CHAR_LIMITS,
+  SNACKBAR_DURATION,
+  SNACKBAR_ICON_SIZE,
+  sizeConfig,
+  stateConfig,
+} from './config'
 import { type SnackbarSize, type SnackbarState } from './types'
 
 export interface RcSesSnackbarProps {
@@ -58,6 +64,10 @@ function RcSesSnackbar({
   const config = stateConfig[state]
   const StateIcon = config.icon
   const isStandard = size === 'standard'
+  const charLimit = SNACKBAR_CHAR_LIMITS[size]
+  const truncatedMessage =
+    message.length > charLimit ? `${message.slice(0, charLimit)}...` : message
+  const isMultiline = truncatedMessage.length > (size === 'standard' ? 80 : 40)
 
   const handleClose = () => {
     setInternalOpen(false)
@@ -92,7 +102,7 @@ function RcSesSnackbar({
         aria-atomic='true'
         sx={{
           display: 'flex',
-          alignItems: 'center',
+          alignItems: isMultiline ? 'flex-start' : 'center',
           gap: theme.spacing(1),
           width: `${sizeConfig[size].width}px`,
           maxHeight: `${sizeConfig[size].maxHeight}px`,
@@ -108,8 +118,9 @@ function RcSesSnackbar({
           sx={{
             flexShrink: 0,
             display: 'flex',
-            alignItems: 'center',
+            alignItems: isMultiline ? 'flex-start' : 'center',
             justifyContent: 'center',
+            pt: isMultiline ? '2px' : 0,
             '& svg': {
               width: `${SNACKBAR_ICON_SIZE.width}px !important`,
               height: `${SNACKBAR_ICON_SIZE.height}px !important`,
@@ -123,14 +134,9 @@ function RcSesSnackbar({
           sx={{
             flex: 1,
             minWidth: 0,
-            overflow: 'hidden',
-            display: '-webkit-box',
-            WebkitBoxOrient: 'vertical',
-            WebkitLineClamp: 3,
-            textOverflow: 'ellipsis',
           }}
         >
-          {message}
+          {truncatedMessage}
         </Typography>
         <Box sx={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
           {onAction && isStandard && (

--- a/src/components/common/Snackbar/index.tsx
+++ b/src/components/common/Snackbar/index.tsx
@@ -6,7 +6,7 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import CloseIcon from '@/assets/icons/CloseIcon'
@@ -67,7 +67,15 @@ function RcSesSnackbar({
   const charLimit = SNACKBAR_CHAR_LIMITS[size]
   const truncatedMessage =
     message.length > charLimit ? `${message.slice(0, charLimit)}...` : message
-  const isMultiline = truncatedMessage.length > (size === 'standard' ? 80 : 40)
+
+  const textRef = useRef<HTMLSpanElement>(null)
+  const [isMultiline, setIsMultiline] = useState(false)
+  useLayoutEffect(() => {
+    const el = textRef.current
+    if (!el) return
+    const singleLineHeight = parseFloat(getComputedStyle(el).lineHeight)
+    setIsMultiline(el.clientHeight > singleLineHeight + 4)
+  }, [truncatedMessage])
 
   const handleClose = () => {
     setInternalOpen(false)
@@ -130,6 +138,7 @@ function RcSesSnackbar({
           <StateIcon fillColor={config.color} aria-hidden />
         </Box>
         <Typography
+          ref={textRef}
           variant='body2'
           sx={{
             flex: 1,

--- a/src/components/layout/ServiceHeader.tsx
+++ b/src/components/layout/ServiceHeader.tsx
@@ -1,5 +1,5 @@
 import { Box, Container, Typography } from '@mui/material'
-import React from 'react'
+import React, { type CSSProperties } from 'react'
 
 import RcSesBreadcrumbs from '@/components/common/Breadcrumbs'
 import theme from '@/theme/light'
@@ -9,7 +9,7 @@ type Props = {
   breadcrumbsProps: React.ComponentProps<typeof RcSesBreadcrumbs>
   children?: React.ReactNode
   title: string
-  backgroundColor?: string
+  backgroundColor?: CSSProperties['backgroundColor']
 }
 function ServiceHeader({
   breadcrumbsProps,

--- a/src/components/layout/ServiceHeader.tsx
+++ b/src/components/layout/ServiceHeader.tsx
@@ -3,24 +3,22 @@ import React from 'react'
 
 import RcSesBreadcrumbs from '@/components/common/Breadcrumbs'
 import theme from '@/theme/light'
-import Colors, { common } from '@/theme/palette'
+import { common } from '@/theme/palette'
 
 type Props = {
   breadcrumbsProps: React.ComponentProps<typeof RcSesBreadcrumbs>
   children?: React.ReactNode
   title: string
-  backgroundColor?: 'primary' | 'white'
+  backgroundColor?: string
 }
 function ServiceHeader({
   breadcrumbsProps,
   children,
   title,
-  backgroundColor = 'primary',
+  backgroundColor = common.white,
 }: Props) {
-  const bgColor = backgroundColor === 'white' ? common.white : Colors.primary['50']
-
   return (
-    <Box sx={{ backgroundColor: bgColor }}>
+    <Box sx={{ backgroundColor }}>
       <Container
         sx={{
           pb: { xs: '2rem', md: '2.25rem' },

--- a/src/stories/components/feedback/Snackbar.stories.tsx
+++ b/src/stories/components/feedback/Snackbar.stories.tsx
@@ -463,7 +463,7 @@ function SnackbarDemoLongText() {
           showSnackbar({
             state: 'info',
             message:
-              'Tai yra labai ilgas pranešimas kuris turėtų būti trumpintas su elipsu jei nepakanka vietos komponente. Šis tekstas skirtas testuoti teksto trumpinimą',
+              'Tai yra labai ilgas pranešimas kuris turėtų būti trumpintas su elipsu jei nepakanka vietos komponente. Šis tekstas skirtas testuoti teksto trumpinimą, tai yra labai labai labai ilgas tekstas testavimui.',
             showClose: true,
           })
         }

--- a/src/stories/components/layout/ServiceHeader.stories.tsx
+++ b/src/stories/components/layout/ServiceHeader.stories.tsx
@@ -3,8 +3,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
 import RcSesServiceHeader from '@/components/layout/ServiceHeader'
-
-type ServiceHeaderProps = React.ComponentProps<typeof RcSesServiceHeader>
+import { common, grey } from '@/theme/palette'
 
 const meta: Meta<typeof RcSesServiceHeader> = {
   title: 'components/layout/ServiceHeader',
@@ -13,13 +12,7 @@ const meta: Meta<typeof RcSesServiceHeader> = {
   argTypes: {
     title: { control: 'text' },
     children: { control: 'text' },
-    backgroundColor: {
-      control: 'inline-radio',
-      options: ['primary', 'white'],
-      table: {
-        defaultValue: { summary: 'primary' },
-      },
-    },
+    backgroundColor: { control: 'text' },
   },
 }
 
@@ -39,31 +32,31 @@ export const Default: Story = {
     title: 'Service Title',
     children: 'This is a description of the service.',
     breadcrumbsProps: breadcrumbs,
-    backgroundColor: 'primary',
+    backgroundColor: common.white,
   },
   render: (args) => (
     <RcSesServiceHeader
       title={args.title}
       breadcrumbsProps={args.breadcrumbsProps}
-      backgroundColor={args.backgroundColor as ServiceHeaderProps['backgroundColor']}
+      backgroundColor={args.backgroundColor}
     >
       {args.children && <Typography variant='body1'>{args.children}</Typography>}
     </RcSesServiceHeader>
   ),
 }
 
-export const WhiteBackground: Story = {
+export const CustomBackground: Story = {
   args: {
     title: 'Service Title',
-    children: 'This is a description of the service.',
+    children: 'This is a description of the service with custom background.',
     breadcrumbsProps: breadcrumbs,
-    backgroundColor: 'white',
+    backgroundColor: grey['100'],
   },
   render: (args) => (
     <RcSesServiceHeader
       title={args.title}
       breadcrumbsProps={args.breadcrumbsProps}
-      backgroundColor={args.backgroundColor as ServiceHeaderProps['backgroundColor']}
+      backgroundColor={args.backgroundColor}
     >
       {args.children && <Typography variant='body1'>{args.children}</Typography>}
     </RcSesServiceHeader>


### PR DESCRIPTION
## 🔗 Task

Contributes to https://jira.registrucentras.lt/jira/browse/SAV-5592
Contributes to https://jira.registrucentras.lt/jira/browse/SAV-5385

## 🧾 Summary

Implemented what I see fits from the UX comment (in the Jira [task](https://jira.registrucentras.lt/jira/browse/SAV-5592)):

✅ Added char limit: 120 char (Standard) and 60 (Compact)
✅ Aligned icon at the top when there're multiple text lines (see screenshot below)
❌ No changes for the min-width/max-width - I'd say keep it fixed, as it looks good on both mobile/desktop.

<img width="1067" height="505" alt="image" src="https://github.com/user-attachments/assets/0aa86736-5f4e-4a5e-887f-5cb7e014a3e4" />

✅ Made `ServiceHeader` background white by default everywhere (but left an option to pass custom bg color):

<img width="814" height="990" alt="image" src="https://github.com/user-attachments/assets/5d8947f1-e927-4151-95f8-e39bd5c3dbbf" />




## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [x] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

N/A

<!-- Potential regressions or trade-offs -->
