### PR TITLE
SAV-5705: create Dialog component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@registrucentras/rc-ses-react-components",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
         "@fontsource/public-sans": "^5.0.18",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@registrucentras/rc-ses-react-components",
   "author": "VĮ REGISTRŲ CENTRAS",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "RC SES React komponentų biblioteka",
   "type": "module",
   "private": false,

--- a/src/assets/icons/CheckCircleFillIcon.tsx
+++ b/src/assets/icons/CheckCircleFillIcon.tsx
@@ -2,13 +2,19 @@ import { CheckCircleIcon as CheckCircleFillIcon } from '@phosphor-icons/react'
 
 import IconProps from '../IconProps'
 
-function CheckCircleIcon({ className, fillColor, size = 24, ...rest }: IconProps) {
+function CheckCircleIcon({
+  className,
+  fillColor,
+  size = 24,
+  weight = 'fill',
+  ...rest
+}: IconProps) {
   return (
     <CheckCircleFillIcon
       {...rest}
       className={className}
       size={size}
-      weight='fill'
+      weight={weight}
       color={fillColor}
     />
   )

--- a/src/assets/icons/InfoFillIcon.tsx
+++ b/src/assets/icons/InfoFillIcon.tsx
@@ -2,9 +2,15 @@ import { InfoIcon as Info } from '@phosphor-icons/react'
 
 import IconProps from '../IconProps'
 
-function InfoFillIcon({ className, size = 24, fillColor, ...rest }: IconProps) {
+function InfoFillIcon({
+  className,
+  size = 24,
+  fillColor,
+  weight = 'fill',
+  ...rest
+}: IconProps) {
   return (
-    <Info {...rest} className={className} size={size} weight='fill' color={fillColor} />
+    <Info {...rest} className={className} size={size} weight={weight} color={fillColor} />
   )
 }
 

--- a/src/assets/icons/QuestionFillIcon.tsx
+++ b/src/assets/icons/QuestionFillIcon.tsx
@@ -2,13 +2,19 @@ import { QuestionIcon as Question } from '@phosphor-icons/react'
 
 import IconProps from '../IconProps'
 
-function QuestionFillIcon({ className, size = 16, fillColor, ...rest }: IconProps) {
+function QuestionFillIcon({
+  className,
+  size = 16,
+  fillColor,
+  weight = 'fill',
+  ...rest
+}: IconProps) {
   return (
     <Question
       {...rest}
       className={className}
       size={size}
-      weight='fill'
+      weight={weight}
       color={fillColor}
     />
   )

--- a/src/assets/icons/WarningFillIcon.tsx
+++ b/src/assets/icons/WarningFillIcon.tsx
@@ -2,13 +2,19 @@ import { WarningIcon as Warning } from '@phosphor-icons/react'
 
 import IconProps from '../IconProps'
 
-function WarningFillIcon({ className, size = 24, fillColor, ...rest }: IconProps) {
+function WarningFillIcon({
+  className,
+  size = 24,
+  fillColor,
+  weight = 'fill',
+  ...rest
+}: IconProps) {
   return (
     <Warning
       {...rest}
       className={className}
       size={size}
-      weight='fill'
+      weight={weight}
       color={fillColor}
     />
   )

--- a/src/components/overlays/Dialog/index.test.tsx
+++ b/src/components/overlays/Dialog/index.test.tsx
@@ -43,6 +43,24 @@ describe('RcSesDialog', () => {
     expect(paper).toHaveStyle({ width: '600px' })
   })
 
+  it('should apply small size (480px)', () => {
+    render(
+      <RcSesDialog open size='sm' dialogTitle='Test Title' actions={<Button>Close</Button>} />,
+    )
+
+    const paper = document.querySelector('.MuiDialog-paper')
+    expect(paper).toHaveStyle({ width: '480px' })
+  })
+
+  it('should apply large size (800px)', () => {
+    render(
+      <RcSesDialog open size='lg' dialogTitle='Test Title' actions={<Button>Close</Button>} />,
+    )
+
+    const paper = document.querySelector('.MuiDialog-paper')
+    expect(paper).toHaveStyle({ width: '800px' })
+  })
+
   it('should render ReactNode as title', () => {
     render(
       <RcSesDialog

--- a/src/components/overlays/Dialog/index.test.tsx
+++ b/src/components/overlays/Dialog/index.test.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@mui/material'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import RcSesDialog from './index'
+
+describe('RcSesDialog', () => {
+  it('should render dialog title', () => {
+    render(<RcSesDialog open dialogTitle='Test Title' actions={<Button>Close</Button>} />)
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument()
+  })
+
+  it('should render children when provided', () => {
+    render(
+      <RcSesDialog open dialogTitle='Test Title' actions={<Button>Close</Button>}>
+        Test Content
+      </RcSesDialog>,
+    )
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument()
+  })
+
+  it('should not render DialogContent when children are not provided', () => {
+    render(<RcSesDialog open dialogTitle='Test Title' actions={<Button>Close</Button>} />)
+
+    const dialogContent = document.querySelector('.MuiDialogContent-root')
+    expect(dialogContent).not.toBeInTheDocument()
+  })
+
+  it('should render actions', () => {
+    render(
+      <RcSesDialog open dialogTitle='Test Title' actions={<Button>Submit</Button>} />,
+    )
+
+    expect(screen.getByText('Submit')).toBeInTheDocument()
+  })
+
+  it('should apply medium size by default', () => {
+    render(<RcSesDialog open dialogTitle='Test Title' actions={<Button>Close</Button>} />)
+
+    const paper = document.querySelector('.MuiDialog-paper')
+    expect(paper).toHaveStyle({ width: '600px' })
+  })
+
+  it('should render ReactNode as title', () => {
+    render(
+      <RcSesDialog
+        open
+        dialogTitle={<h2>Custom Title Element</h2>}
+        actions={<Button>Close</Button>}
+      />,
+    )
+
+    expect(screen.getByText('Custom Title Element')).toBeInTheDocument()
+  })
+})

--- a/src/components/overlays/Dialog/index.test.tsx
+++ b/src/components/overlays/Dialog/index.test.tsx
@@ -45,7 +45,12 @@ describe('RcSesDialog', () => {
 
   it('should apply small size (480px)', () => {
     render(
-      <RcSesDialog open size='sm' dialogTitle='Test Title' actions={<Button>Close</Button>} />,
+      <RcSesDialog
+        open
+        size='sm'
+        dialogTitle='Test Title'
+        actions={<Button>Close</Button>}
+      />,
     )
 
     const paper = document.querySelector('.MuiDialog-paper')
@@ -54,7 +59,12 @@ describe('RcSesDialog', () => {
 
   it('should apply large size (800px)', () => {
     render(
-      <RcSesDialog open size='lg' dialogTitle='Test Title' actions={<Button>Close</Button>} />,
+      <RcSesDialog
+        open
+        size='lg'
+        dialogTitle='Test Title'
+        actions={<Button>Close</Button>}
+      />,
     )
 
     const paper = document.querySelector('.MuiDialog-paper')

--- a/src/components/overlays/Dialog/index.tsx
+++ b/src/components/overlays/Dialog/index.tsx
@@ -15,7 +15,7 @@ const SIZE_MAP: Record<DialogSize, string> = {
   lg: '800px',
 }
 
-export interface RcSesDialogProps extends Omit<MuiDialogProps, 'children' | 'title'> {
+export interface RcSesDialogProps extends Omit<MuiDialogProps, 'children' | 'title' | 'PaperProps' | 'maxWidth'> {
   dialogTitle: string | ReactNode
   children?: ReactNode
   actions: ReactNode
@@ -42,7 +42,6 @@ function RcSesDialog({
       PaperProps={{ sx: { width: dialogWidth, borderRadius: '16px' } }}
       aria-labelledby={titleId}
       aria-describedby={children ? contentId : undefined}
-      aria-modal
     >
       <DialogTitle
         id={titleId}

--- a/src/components/overlays/Dialog/index.tsx
+++ b/src/components/overlays/Dialog/index.tsx
@@ -1,0 +1,85 @@
+import {
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Dialog as MuiDialog,
+  DialogProps as MuiDialogProps,
+} from '@mui/material'
+import { ReactNode, useId } from 'react'
+
+export type DialogSize = 'sm' | 'md' | 'lg'
+
+const SIZE_MAP: Record<DialogSize, string> = {
+  sm: '480px',
+  md: '600px',
+  lg: '800px',
+}
+
+export interface RcSesDialogProps extends Omit<MuiDialogProps, 'children' | 'title'> {
+  dialogTitle: string | ReactNode
+  children?: ReactNode
+  actions: ReactNode
+  size?: DialogSize
+}
+
+function RcSesDialog({
+  dialogTitle,
+  children,
+  actions,
+  onClose,
+  size = 'md',
+  ...props
+}: RcSesDialogProps) {
+  const dialogWidth = SIZE_MAP[size]
+  const titleId = useId()
+  const contentId = useId()
+
+  return (
+    <MuiDialog
+      onClose={onClose}
+      {...props}
+      maxWidth={false}
+      PaperProps={{ sx: { width: dialogWidth, borderRadius: '16px' } }}
+      aria-labelledby={titleId}
+      aria-describedby={children ? contentId : undefined}
+      aria-modal
+    >
+      <DialogTitle
+        id={titleId}
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          fontSize: '24px',
+          lineHeight: '32px',
+          padding: '2rem 2rem 1rem !important',
+        }}
+      >
+        {dialogTitle}
+      </DialogTitle>
+
+      {children && (
+        <DialogContent
+          id={contentId}
+          sx={{
+            padding: '0 2rem !important',
+          }}
+        >
+          {children}
+        </DialogContent>
+      )}
+
+      {actions && (
+        <DialogActions
+          sx={{
+            padding: '1.25rem 2rem 2rem !important',
+          }}
+        >
+          {actions}
+        </DialogActions>
+      )}
+    </MuiDialog>
+  )
+}
+
+export default RcSesDialog

--- a/src/components/overlays/Dialog/index.tsx
+++ b/src/components/overlays/Dialog/index.tsx
@@ -15,7 +15,8 @@ const SIZE_MAP: Record<DialogSize, string> = {
   lg: '800px',
 }
 
-export interface RcSesDialogProps extends Omit<MuiDialogProps, 'children' | 'title' | 'PaperProps' | 'maxWidth'> {
+export interface RcSesDialogProps
+  extends Omit<MuiDialogProps, 'children' | 'title' | 'PaperProps' | 'maxWidth'> {
   dialogTitle: string | ReactNode
   children?: ReactNode
   actions: ReactNode

--- a/src/components/overlays/Modal/index.test.tsx
+++ b/src/components/overlays/Modal/index.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import i18n from 'i18next'
+import { I18nextProvider } from 'react-i18next'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import inputEn from '@/i18n/namespaces/input/en.json'
+import inputLt from '@/i18n/namespaces/input/lt.json'
+
+import RcSesModal from './index'
+
+beforeAll(() => {
+  if (!i18n.isInitialized) {
+    i18n.init({
+      lng: 'lt',
+      resources: {
+        lt: { input: inputLt },
+        en: { input: inputEn },
+      },
+    })
+  }
+})
+
+describe('RcSesModal', () => {
+  it('renders title and message', () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <RcSesModal
+          open
+          onClose={vi.fn()}
+          title='Test Title'
+          message='Test Message'
+          onPrimaryAction={vi.fn()}
+        />
+      </I18nextProvider>,
+    )
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument()
+    expect(screen.getByText('Test Message')).toBeInTheDocument()
+  })
+
+  it('renders success variant with only primary button', () => {
+    const onPrimary = vi.fn()
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <RcSesModal
+          open
+          onClose={vi.fn()}
+          title='Success!'
+          message='Operation complete'
+          variant='success'
+          onPrimaryAction={onPrimary}
+        />
+      </I18nextProvider>,
+    )
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.length).toBe(1)
+  })
+
+  it('uses custom primary label when provided', () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <RcSesModal
+          open
+          onClose={vi.fn()}
+          title='Test'
+          message='Test Message'
+          primaryActionLabel='Custom Label'
+          onPrimaryAction={vi.fn()}
+        />
+      </I18nextProvider>,
+    )
+
+    expect(screen.getByText('Custom Label')).toBeInTheDocument()
+  })
+
+  it('renders custom actions when provided', () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <RcSesModal
+          open
+          onClose={vi.fn()}
+          title='Test'
+          message='Test Message'
+          actions={<button type='button'>Custom Action</button>}
+          onPrimaryAction={vi.fn()}
+        />
+      </I18nextProvider>,
+    )
+
+    expect(screen.getByText('Custom Action')).toBeInTheDocument()
+  })
+})

--- a/src/components/overlays/Modal/index.tsx
+++ b/src/components/overlays/Modal/index.tsx
@@ -1,0 +1,116 @@
+import { Button, Typography } from '@mui/material'
+import { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import CheckCircleFillIcon from '@/assets/icons/CheckCircleFillIcon'
+import InfoFillIcon from '@/assets/icons/InfoFillIcon'
+import QuestionFillIcon from '@/assets/icons/QuestionFillIcon'
+import WarningFillIcon from '@/assets/icons/WarningFillIcon'
+import palette from '@/theme/palette'
+
+import RcSesDialog, { RcSesDialogProps } from '../Dialog'
+
+export type ModalVariant = 'destructive' | 'confirm' | 'success' | 'info'
+
+const VARIANT_CONFIG: Record<ModalVariant, { icon: ReactNode }> = {
+  destructive: {
+    icon: <WarningFillIcon size={36} weight='regular' fillColor={palette.error['600']} />,
+  },
+  confirm: {
+    icon: <QuestionFillIcon size={36} weight='regular' fillColor={palette.grey['700']} />,
+  },
+  success: {
+    icon: (
+      <CheckCircleFillIcon
+        size={36}
+        weight='regular'
+        fillColor={palette.secondary['600']}
+      />
+    ),
+  },
+  info: {
+    icon: <InfoFillIcon size={36} weight='regular' fillColor={palette.primary['500']} />,
+  },
+}
+
+export interface RcSesModalProps
+  extends Omit<RcSesDialogProps, 'children' | 'dialogTitle' | 'actions'> {
+  title: string
+  message: ReactNode
+  variant?: ModalVariant
+  showIcon?: boolean
+  onPrimaryAction?: () => void
+  onSecondaryAction?: () => void
+  primaryActionLabel?: string
+  secondaryActionLabel?: string
+  actions?: ReactNode
+}
+
+function RcSesModal({
+  title,
+  message,
+  variant = 'info',
+  showIcon = false,
+  onPrimaryAction,
+  onSecondaryAction,
+  primaryActionLabel,
+  secondaryActionLabel,
+  actions: customActions,
+  ...props
+}: RcSesModalProps) {
+  const { t } = useTranslation('input', { keyPrefix: 'components.Modal' })
+  const config = VARIANT_CONFIG[variant]
+
+  const getPrimaryLabel = () => {
+    if (primaryActionLabel) return primaryActionLabel
+    return t(`actions.${variant}.primary`)
+  }
+
+  const getSecondaryLabel = () => {
+    if (secondaryActionLabel) return secondaryActionLabel
+    return t('actions.cancel')
+  }
+
+  const titleContent = showIcon ? (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 8,
+      }}
+    >
+      <div aria-hidden='true'>{config.icon}</div>
+      {title}
+    </div>
+  ) : (
+    title
+  )
+
+  const defaultActions = (
+    <>
+      {(variant === 'destructive' || variant === 'confirm') && (
+        <Button onClick={onSecondaryAction} variant='outlined' color='grey'>
+          {getSecondaryLabel()}
+        </Button>
+      )}
+      <Button
+        onClick={onPrimaryAction}
+        variant='contained'
+        color={variant === 'destructive' ? 'error' : 'primary'}
+      >
+        {getPrimaryLabel()}
+      </Button>
+    </>
+  )
+
+  const actions = customActions || defaultActions
+
+  return (
+    <RcSesDialog dialogTitle={titleContent} actions={actions} {...props}>
+      <Typography variant='body1'>{message}</Typography>
+    </RcSesDialog>
+  )
+}
+
+export default RcSesModal

--- a/src/i18n/namespaces/input/en.json
+++ b/src/i18n/namespaces/input/en.json
@@ -59,6 +59,24 @@
       "aria": {
         "close": "Close notification"
       }
+    },
+
+    "Modal": {
+      "actions": {
+        "destructive": {
+          "primary": "Remove"
+        },
+        "confirm": {
+          "primary": "Continue"
+        },
+        "success": {
+          "primary": "Close"
+        },
+        "info": {
+          "primary": "I understand"
+        },
+        "cancel": "Cancel"
+      }
     }
   }
 }

--- a/src/i18n/namespaces/input/lt.json
+++ b/src/i18n/namespaces/input/lt.json
@@ -59,6 +59,24 @@
       "aria": {
         "close": "Uždaryti pranešimą"
       }
+    },
+
+    "Modal": {
+      "actions": {
+        "destructive": {
+          "primary": "Pašalinti"
+        },
+        "confirm": {
+          "primary": "Tęsti"
+        },
+        "success": {
+          "primary": "Uždaryti"
+        },
+        "info": {
+          "primary": "Suprantu"
+        },
+        "cancel": "Atšaukti"
+      }
     }
   }
 }

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -46,6 +46,7 @@ import RcSesCardFormContainer from '@/components/layout/ServiceFormContainer/Car
 import RcSesServiceHeader from '@/components/layout/ServiceHeader'
 import RcSesServicePage from '@/components/layout/ServicePage'
 import ServiceWizardStepper from '@/components/layout/ServiceWizardStepper'
+import RcSesDialog from '@/components/overlays/Dialog'
 import RcSesTheme from '@/theme/light'
 import RcSesPalette from '@/theme/palette'
 
@@ -65,6 +66,7 @@ export {
   RcSesButton,
   RcSesButtonWithPopover,
   RcSesCard,
+  RcSesDialog,
   RcSesFooter,
   RcSesImageCard,
   RcSesSnackbar,

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -47,6 +47,7 @@ import RcSesServiceHeader from '@/components/layout/ServiceHeader'
 import RcSesServicePage from '@/components/layout/ServicePage'
 import ServiceWizardStepper from '@/components/layout/ServiceWizardStepper'
 import RcSesDialog from '@/components/overlays/Dialog'
+import RcSesModal from '@/components/overlays/Modal'
 import RcSesTheme from '@/theme/light'
 import RcSesPalette from '@/theme/palette'
 
@@ -71,6 +72,7 @@ export {
   RcSesImageCard,
   RcSesSnackbar,
   RcSesSnackbarProvider,
+  RcSesModal,
 }
 export { RcSesCheckbox, RcSesCheckboxFormControl, RcSesSimpleCheckbox }
 export { useSnackbar }

--- a/src/library/types.ts
+++ b/src/library/types.ts
@@ -6,6 +6,7 @@ import { SimpleCheckboxProps } from '@/components/form/inputs/SimpleCheckbox'
 import { RcSesCardFormContainerProps } from '@/components/layout/ServiceFormContainer/CardFormContainer'
 import { ServiceWizardStepperProps } from '@/components/layout/ServiceWizardStepper'
 import { DialogSize, RcSesDialogProps } from '@/components/overlays/Dialog'
+import { ModalVariant, RcSesModalProps } from '@/components/overlays/Modal'
 import { ButtonProps } from '@/types/buttons/ButtonProps'
 
 export type { ListWithIconsProps, ListWithIconsItemData }
@@ -19,3 +20,4 @@ export type {
   RcSesFormControlLabelProps,
 }
 export type { RcSesDialogProps, DialogSize }
+export type { RcSesModalProps, ModalVariant }

--- a/src/library/types.ts
+++ b/src/library/types.ts
@@ -5,6 +5,7 @@ import { RcSesFormControlLabelProps } from '@/components/form/inputs/FormControl
 import { SimpleCheckboxProps } from '@/components/form/inputs/SimpleCheckbox'
 import { RcSesCardFormContainerProps } from '@/components/layout/ServiceFormContainer/CardFormContainer'
 import { ServiceWizardStepperProps } from '@/components/layout/ServiceWizardStepper'
+import { DialogSize, RcSesDialogProps } from '@/components/overlays/Dialog'
 import { ButtonProps } from '@/types/buttons/ButtonProps'
 
 export type { ListWithIconsProps, ListWithIconsItemData }
@@ -17,3 +18,4 @@ export type {
   SimpleCheckboxProps,
   RcSesFormControlLabelProps,
 }
+export type { RcSesDialogProps, DialogSize }

--- a/src/stories/components/overlays/Dialog.stories.tsx
+++ b/src/stories/components/overlays/Dialog.stories.tsx
@@ -1,0 +1,276 @@
+import { Typography } from '@mui/material'
+import { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import RcSesButton from '@/components/common/Button'
+import RcSesDialog from '@/components/overlays/Dialog'
+
+const meta: Meta<typeof RcSesDialog> = {
+  component: RcSesDialog,
+  title: 'components/overlays/Dialog',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<{
+  dialogTitle: string
+  size?: 'sm' | 'md' | 'lg'
+}>
+
+function DialogStory({
+  dialogTitle,
+  size,
+  children,
+}: {
+  dialogTitle: string
+  size?: 'sm' | 'md' | 'lg'
+  children: React.ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <RcSesButton onClick={() => setOpen(true)} variant='contained'>
+        Open Dialog
+      </RcSesButton>
+      <RcSesDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        dialogTitle={dialogTitle}
+        size={size}
+        actions={
+          <>
+            <RcSesButton onClick={() => setOpen(false)} color='grey' variant='outlined'>
+              Cancel
+            </RcSesButton>
+            <RcSesButton onClick={() => setOpen(false)} variant='contained'>
+              Confirm
+            </RcSesButton>
+          </>
+        }
+      >
+        {children}
+      </RcSesDialog>
+    </>
+  )
+}
+
+export const Basic: Story = {
+  render: (args) => (
+    <DialogStory {...args}>
+      <Typography>Are you sure you want to proceed?</Typography>
+    </DialogStory>
+  ),
+  args: {
+    dialogTitle: 'Confirm Action',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `import { useState } from 'react'
+import { Typography } from '@mui/material'
+import { RcSesButton, RcSesDialog } from '@registrucentras/rc-ses-react-components'
+
+export function BasicDialog() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <RcSesButton onClick={() => setOpen(true)} variant='contained'>
+        Open Dialog
+      </RcSesButton>
+      <RcSesDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        dialogTitle='Confirm Action'
+        actions={
+          <>
+            <RcSesButton onClick={() => setOpen(false)} color='grey' variant='outlined'>
+              Cancel
+            </RcSesButton>
+            <RcSesButton onClick={() => setOpen(false)} variant='contained'>
+              Confirm
+            </RcSesButton>
+          </>
+        }
+      >
+        <Typography>Are you sure you want to proceed?</Typography>
+      </RcSesDialog>
+    </>
+  )
+}`,
+      },
+    },
+  },
+}
+
+export const SmallDialog: Story = {
+  render: (args) => (
+    <DialogStory {...args}>
+      <Typography>
+        This is a <b>small</b> dialog (480px width).
+      </Typography>
+    </DialogStory>
+  ),
+  args: {
+    dialogTitle: 'Small Dialog',
+    size: 'sm',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Small size dialog (480px width).',
+      },
+      source: {
+        code: `import { useState } from 'react'
+import { Typography } from '@mui/material'
+import { RcSesButton, RcSesDialog } from '@registrucentras/rc-ses-react-components'
+
+export function SmallDialog() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <RcSesButton onClick={() => setOpen(true)} variant='contained'>
+        Open Dialog
+      </RcSesButton>
+      <RcSesDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        dialogTitle='Small Dialog'
+        size='sm'
+        actions={
+          <>
+            <RcSesButton onClick={() => setOpen(false)} color='grey' variant='outlined'>
+              Cancel
+            </RcSesButton>
+            <RcSesButton onClick={() => setOpen(false)} variant='contained'>
+              Confirm
+            </RcSesButton>
+          </>
+        }
+      >
+        <Typography>This is a small dialog (480px width).</Typography>
+      </RcSesDialog>
+    </>
+  )
+}`,
+      },
+    },
+  },
+}
+
+export const MediumDialog: Story = {
+  render: (args) => (
+    <DialogStory {...args}>
+      <Typography>
+        This is a <b>medium</b> dialog (600px width).
+      </Typography>
+    </DialogStory>
+  ),
+  args: {
+    dialogTitle: 'Medium Dialog',
+    size: 'md',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Medium size (600px width) dialog. This is the default size.',
+      },
+      source: {
+        code: `import { useState } from 'react'
+import { Typography } from '@mui/material'
+import { RcSesButton, RcSesDialog } from '@registrucentras/rc-ses-react-components'
+
+export function MediumDialog() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <RcSesButton onClick={() => setOpen(true)} variant='contained'>
+        Open Dialog
+      </RcSesButton>
+      <RcSesDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        dialogTitle='Medium Dialog'
+        size='md'
+        actions={
+          <>
+            <RcSesButton onClick={() => setOpen(false)} color='grey' variant='outlined'>
+              Cancel
+            </RcSesButton>
+            <RcSesButton onClick={() => setOpen(false)} variant='contained'>
+              Confirm
+            </RcSesButton>
+          </>
+        }
+      >
+        <Typography>This is a medium dialog (600px width).</Typography>
+      </RcSesDialog>
+    </>
+  )
+}`,
+      },
+    },
+  },
+}
+
+export const LargeDialog: Story = {
+  render: (args) => (
+    <DialogStory {...args}>
+      <Typography>
+        This is a <b>large</b> dialog (800px width).
+      </Typography>
+    </DialogStory>
+  ),
+  args: {
+    dialogTitle: 'Large Dialog',
+    size: 'lg',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Large size (800px width) dialog for content-heavy forms or information.',
+      },
+      source: {
+        code: `import { useState } from 'react'
+import { Typography } from '@mui/material'
+import { RcSesButton, RcSesDialog } from '@registrucentras/rc-ses-react-components'
+
+export function LargeDialog() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <RcSesButton onClick={() => setOpen(true)} variant='contained'>
+        Open Dialog
+      </RcSesButton>
+      <RcSesDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        dialogTitle='Large Dialog'
+        size='lg'
+        actions={
+          <>
+            <RcSesButton onClick={() => setOpen(false)} color='grey' variant='outlined'>
+              Cancel
+            </RcSesButton>
+            <RcSesButton onClick={() => setOpen(false)} variant='contained'>
+              Confirm
+            </RcSesButton>
+          </>
+        }
+      >
+        <Typography>This is a large dialog (800px width).</Typography>
+      </RcSesDialog>
+    </>
+  )
+}`,
+      },
+    },
+  },
+}

--- a/src/stories/components/overlays/Dialog.stories.tsx
+++ b/src/stories/components/overlays/Dialog.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 
 import RcSesButton from '@/components/common/Button'
-import RcSesDialog from '@/components/overlays/Dialog'
+import RcSesDialog, { RcSesDialogProps } from '@/components/overlays/Dialog'
 
 const meta: Meta<typeof RcSesDialog> = {
   component: RcSesDialog,
@@ -15,20 +15,14 @@ const meta: Meta<typeof RcSesDialog> = {
 }
 
 export default meta
-type Story = StoryObj<{
-  dialogTitle: string
-  size?: 'sm' | 'md' | 'lg'
-}>
+type Story = StoryObj<typeof RcSesDialog>
 
 function DialogStory({
   dialogTitle,
   size,
   children,
-}: {
-  dialogTitle: string
-  size?: 'sm' | 'md' | 'lg'
-  children: React.ReactNode
-}) {
+  ...props
+}: RcSesDialogProps & { children: React.ReactNode }) {
   const [open, setOpen] = useState(false)
 
   return (
@@ -37,6 +31,7 @@ function DialogStory({
         Open Dialog
       </RcSesButton>
       <RcSesDialog
+        {...props}
         open={open}
         onClose={() => setOpen(false)}
         dialogTitle={dialogTitle}

--- a/src/stories/components/overlays/Modal.stories.tsx
+++ b/src/stories/components/overlays/Modal.stories.tsx
@@ -1,0 +1,98 @@
+import { Button } from '@mui/material'
+import { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import RcSesModal from '@/components/overlays/Modal'
+
+const meta: Meta<typeof RcSesModal> = {
+  component: RcSesModal,
+  title: 'components/overlays/Modal',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof RcSesModal>
+
+function ModalDemo(args: any) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} variant='contained'>
+        Open Modal
+      </Button>
+      <RcSesModal
+        {...args}
+        open={open}
+        onClose={() => setOpen(false)}
+        onPrimaryAction={() => setOpen(false)}
+        onSecondaryAction={() => setOpen(false)}
+      />
+    </>
+  )
+}
+
+export const Destructive: Story = {
+  render: (args) => <ModalDemo {...args} />,
+  args: {
+    title: 'Ar tikrai norite pašalinti?',
+    message: 'Aprašymo tekstas.',
+    variant: 'destructive',
+    secondaryActionLabel: 'Atšaukti',
+    showIcon: true,
+
+    primaryActionLabel: 'Pašalinti',
+  },
+}
+
+export const Confirm: Story = {
+  render: (args) => <ModalDemo {...args} />,
+  args: {
+    title: 'Ar tikrai norite tęsti?',
+    message: 'Aprašymo tekstas.',
+    variant: 'confirm',
+    showIcon: true,
+
+    secondaryActionLabel: 'Atšaukti',
+    primaryActionLabel: 'Tęsti',
+  },
+}
+
+export const Success: Story = {
+  render: (args) => <ModalDemo {...args} />,
+  args: {
+    title: 'Pavyko!',
+    message: 'Aprašymo tekstas.',
+    variant: 'success',
+    showIcon: true,
+
+    primaryActionLabel: 'Uždaryti',
+  },
+}
+
+export const Info: Story = {
+  render: (args) => <ModalDemo {...args} />,
+  args: {
+    title: 'Informacija',
+    message: 'Aprašymo tekstas.',
+    variant: 'info',
+    showIcon: true,
+
+    primaryActionLabel: 'Suprantu',
+  },
+}
+
+export const WithoutIcon: Story = {
+  render: (args) => <ModalDemo {...args} />,
+  args: {
+    title: 'Ar tikrai norite pašalinti?',
+    message: 'Aprašymo tekstas.',
+    variant: 'destructive',
+    showIcon: false,
+    secondaryActionLabel: 'Atšaukti',
+    primaryActionLabel: 'Pašalinti',
+  },
+}


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/SAV-5705

## 🧾 Summary

<!-- Brief explanation of what this PR does and why -->

This is generic, basic `Dialog` component which can have custom `title`, `children`, `actions`. There're 3 size options: `sm`, `md` (default), `lg`.

Exact styling as the task needs will be applied separately (as the new component) by using this Dialog component as the base.

## 📸 Screenshots

Storybook: https://ses-react-storybook.registrucentras.lt/preview/SAV-5705-create-reusable-dialog-component/?path=/docs/components-overlays-dialog--docs


<img width="1176" height="968" alt="image" src="https://github.com/user-attachments/assets/9009caf6-6c3a-4fa0-a7c5-c853cdae380e" />


<!-- Visual proof of changes -->

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

N/A as component is not used yet.

<!-- Potential regressions or trade-offs -->
