### PR TITLE
Fix test warnings in the build

### DIFF
--- a/src/components/common/Snackbar/index.test.tsx
+++ b/src/components/common/Snackbar/index.test.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@mui/material/styles'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -20,7 +20,9 @@ describe('RcSesSnackbar', () => {
   })
 
   afterEach(() => {
-    vi.runOnlyPendingTimers()
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
     vi.useRealTimers()
   })
 
@@ -67,7 +69,9 @@ describe('RcSesSnackbar', () => {
     const statusElement = screen.getByText('Test')
     expect(statusElement).toBeInTheDocument()
 
-    vi.advanceTimersByTime(1000)
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
 
     expect(handleClose).toHaveBeenCalled()
   })
@@ -78,7 +82,9 @@ describe('RcSesSnackbar', () => {
       <RcSesSnackbar {...DEFAULT_PROPS} onClose={handleClose} persist duration={1000} />,
     )
 
-    vi.advanceTimersByTime(2000)
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
 
     expect(handleClose).not.toHaveBeenCalled()
   })

--- a/src/components/form/inputs/CheckboxFormControl.test.tsx
+++ b/src/components/form/inputs/CheckboxFormControl.test.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@mui/material/styles'
-import { render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { useForm } from 'react-hook-form'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -40,7 +40,7 @@ describe('RcSesCheckboxFormControl - Indeterminate State', () => {
     expect(checkbox.checked).toBe(false)
   })
 
-  test('should call onChildValuesChange with [true, true, true] when clicking parent in indeterminate state', () => {
+  test('should call onChildValuesChange with [true, true, true] when clicking parent in indeterminate state', async () => {
     const onChildValuesChange = vi.fn()
     const { container } = render(
       <TestWrapper
@@ -49,11 +49,13 @@ describe('RcSesCheckboxFormControl - Indeterminate State', () => {
       />,
     )
     const checkbox = container.querySelector('input#checkbox') as HTMLInputElement
-    checkbox.click()
-    expect(onChildValuesChange).toHaveBeenCalledWith([true, true, true])
+    fireEvent.click(checkbox)
+    await waitFor(() => {
+      expect(onChildValuesChange).toHaveBeenCalledWith([true, true, true])
+    })
   })
 
-  test('should call onChildValuesChange with [false, false, false] when clicking checked parent', () => {
+  test('should call onChildValuesChange with [false, false, false] when clicking checked parent', async () => {
     const onChildValuesChange = vi.fn()
     const { container } = render(
       <TestWrapper
@@ -62,7 +64,9 @@ describe('RcSesCheckboxFormControl - Indeterminate State', () => {
       />,
     )
     const checkbox = container.querySelector('input#checkbox') as HTMLInputElement
-    checkbox.click()
-    expect(onChildValuesChange).toHaveBeenCalledWith([false, false, false])
+    fireEvent.click(checkbox)
+    await waitFor(() => {
+      expect(onChildValuesChange).toHaveBeenCalledWith([false, false, false])
+    })
   })
 })

--- a/src/components/overlays/Dialog/index.test.tsx
+++ b/src/components/overlays/Dialog/index.test.tsx
@@ -75,7 +75,7 @@ describe('RcSesDialog', () => {
     render(
       <RcSesDialog
         open
-        dialogTitle={<h2>Custom Title Element</h2>}
+        dialogTitle={<span>Custom Title Element</span>}
         actions={<Button>Close</Button>}
       />,
     )

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom/vitest'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+if (!i18n.isInitialized) {
+  i18n.use(initReactI18next).init({
+    fallbackLng: 'lt',
+    interpolation: { escapeValue: false },
+    lng: 'lt',
+    resources: {
+      lt: { translation: {} },
+    },
+  })
+}


### PR DESCRIPTION
## 🔗 Task

N/A, we noticed warnings when building 1.8.0 version

## 🧾 Summary

We had some non-blocking warnings in the build -> test (check here to see them: https://github.com/registrucentras/rc-ses-react-components/actions/runs/26621384041/job/78447912034)

Now warnings are fixed (check build -> test in PR: https://github.com/registrucentras/rc-ses-react-components/actions/runs/26746189397/job/78822165777?pr=103):

<img width="1364" height="967" alt="image" src="https://github.com/user-attachments/assets/b7547e2c-b30c-44ec-b217-4a8a81a246f3" />

## 📸 Screenshots

N/A

## ✅ Checklist

* [ ] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

N/A
