### PR TITLE
Update: Pencil icon weight option

### DIFF
--- a/src/assets/icons/PencilSimpleLineIcon.tsx
+++ b/src/assets/icons/PencilSimpleLineIcon.tsx
@@ -6,7 +6,7 @@ function PencilSimpleLineIcon({
   className,
   fillColor,
   size = 24,
-  weight,
+  weight = 'regular',
   ...rest
 }: IconProps) {
   return (
@@ -14,7 +14,7 @@ function PencilSimpleLineIcon({
       {...rest}
       className={className}
       size={size}
-      weight={weight || 'regular'}
+      weight={weight}
       color={fillColor}
     />
   )

--- a/src/assets/icons/PencilSimpleLineIcon.tsx
+++ b/src/assets/icons/PencilSimpleLineIcon.tsx
@@ -2,13 +2,19 @@ import { PencilSimpleLineIcon as PencilSimpleLine } from '@phosphor-icons/react'
 
 import IconProps from '../IconProps'
 
-function PencilSimpleLineIcon({ className, fillColor, size = 24, ...rest }: IconProps) {
+function PencilSimpleLineIcon({
+  className,
+  fillColor,
+  size = 24,
+  weight,
+  ...rest
+}: IconProps) {
   return (
     <PencilSimpleLine
       {...rest}
       className={className}
       size={size}
-      weight='fill'
+      weight={weight || 'regular'}
       color={fillColor}
     />
   )


### PR DESCRIPTION
## 🔗 Task

<!-- Link the related issue or ticket (e.g., Jira issue) -->

## 🧾 Summary

Updated PencilSimpleLineIcon to support the weight prop and forward it to the underlying Phosphor icon component.

- Added weight prop support to PencilSimpleLineIcon.
- Changed the default icon weight from 'fill' to 'regular'.
- Icons can now be rendered with different Phosphor weights (e.g. regular, fill, bold, duotone) when needed.
- Preserved backward compatibility by using 'regular' as the fallback value when weight is not provided.

## 📸 Screenshots

<img width="180" height="74" alt="image" src="https://github.com/user-attachments/assets/0979ca81-0330-414f-8fa2-44517b4c4065" />


## ✅ Checklist

* [ ] Component added/updated in Storybook (if applicable)
* [ ] Tests added/updated
* [+] UI matches approved design (Figma)
* [+] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

- Existing consumers that relied on the icon being rendered with the fill variant by default will now receive the regular variant unless they explicitly pass weight="fill".
- Minor visual differences may appear in places where the icon was previously expected to be filled.
