### PR TITLE
SAV-6142: add SegmentedControl component

### DIFF
--- a/src/components/common/SegmentedControl/components/SegmentButton/index.test.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+
+import RcSesSegmentButton, { type RcSesSegmentOption } from './index'
+
+describe('RcSesSegmentButton', () => {
+  const defaultOption: RcSesSegmentOption = {
+    id: 'option-1',
+    label: 'Option 1',
+    disabled: false,
+  }
+
+  const defaultProps = {
+    option: defaultOption,
+    isSelected: false,
+    isFocused: false,
+    size: 'regular' as const,
+    ariaRole: 'radio' as const,
+    onClick: vi.fn(),
+    onKeyDown: vi.fn(),
+    onFocus: vi.fn(),
+  }
+
+  test('renders button wtesth option label', () => {
+    render(<RcSesSegmentButton {...defaultProps} />)
+    expect(screen.getByRole('radio', { name: 'Option 1' })).toBeInTheDocument()
+  })
+
+  test('calls onClick handler when clicked', () => {
+    const onClick = vi.fn()
+
+    render(<RcSesSegmentButton {...defaultProps} onClick={onClick} />)
+
+    fireEvent.click(screen.getByRole('radio'))
+    expect(onClick).toHaveBeenCalledWith('option-1')
+  })
+
+  test('calls onFocus handler when focused', () => {
+    const onFocus = vi.fn()
+
+    render(<RcSesSegmentButton {...defaultProps} onFocus={onFocus} />)
+
+    fireEvent.focus(screen.getByRole('radio'))
+    expect(onFocus).toHaveBeenCalled()
+  })
+
+  test('calls onKeyDown handler when key pressed', () => {
+    const onKeyDown = vi.fn()
+
+    render(<RcSesSegmentButton {...defaultProps} onKeyDown={onKeyDown} />)
+
+    const button = screen.getByRole('radio')
+    fireEvent.keyDown(button, { key: 'ArrowRight', code: 'ArrowRight' })
+    expect(onKeyDown).toHaveBeenCalled()
+  })
+
+  test('disables button when option.disabled is true', () => {
+    render(
+      <RcSesSegmentButton
+        {...defaultProps}
+        option={{ ...defaultOption, disabled: true }}
+      />,
+    )
+
+    expect(screen.getByRole('radio')).toBeDisabled()
+  })
+
+  test('sets aria-checked when selected', () => {
+    render(<RcSesSegmentButton {...defaultProps} isSelected />)
+
+    expect(screen.getByRole('radio')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  test('sets tabIndex to 0 when focused', () => {
+    render(<RcSesSegmentButton {...defaultProps} isFocused />)
+
+    expect(screen.getByRole('radio')).toHaveAttribute('tabIndex', '0')
+  })
+
+  test('supports tab role', () => {
+    render(<RcSesSegmentButton {...defaultProps} ariaRole='tab' />)
+
+    expect(screen.getByRole('tab')).toBeInTheDocument()
+  })
+})

--- a/src/components/common/SegmentedControl/components/SegmentButton/index.test.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.test.tsx
@@ -21,7 +21,7 @@ describe('RcSesSegmentButton', () => {
     onFocus: vi.fn(),
   }
 
-  test('renders button wtesth option label', () => {
+  test('renders button with option label', () => {
     render(<RcSesSegmentButton {...defaultProps} />)
     expect(screen.getByRole('radio', { name: 'Option 1' })).toBeInTheDocument()
   })

--- a/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
@@ -5,14 +5,14 @@ import { grey, primary } from '@/theme/palette'
 
 const SIZE_STYLES: Record<'small' | 'regular', React.CSSProperties> = {
   small: {
-    width: '160px',
+    width: 'auto',
     minHeight: '36px',
     padding: '8px 12px',
     fontSize: '14px',
     lineHeight: '20px',
   },
   regular: {
-    width: '180px',
+    width: 'auto',
     minHeight: '44px',
     padding: '10px 16px',
     fontSize: '15px',

--- a/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
@@ -88,8 +88,8 @@ const RcSesSegmentButton = React.forwardRef<HTMLButtonElement, RcSesSegmentButto
         onFocus={onFocus}
         disabled={isDisabled}
         role={ariaRole}
-        aria-checked={isSelected}
-        aria-selected={isSelected}
+        aria-checked={ariaRole === 'radio' ? isSelected : undefined}
+        aria-selected={ariaRole === 'tab' ? isSelected : undefined}
         tabIndex={isFocused && !isDisabled ? 0 : -1}
         sx={{
           ...buttonStyles,

--- a/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
@@ -26,6 +26,7 @@ export interface RcSesSegmentOption {
   id: string
   label: string
   disabled?: boolean
+  panelId?: string
 }
 
 export interface RcSesSegmentButtonProps {
@@ -92,6 +93,7 @@ const RcSesSegmentButton = React.forwardRef<HTMLButtonElement, RcSesSegmentButto
         role={ariaRole}
         aria-checked={ariaRole === 'radio' ? isSelected : undefined}
         aria-selected={ariaRole === 'tab' ? isSelected : undefined}
+        aria-controls={option.panelId}
         tabIndex={isFocused && !isDisabled ? 0 : -1}
         sx={{
           ...buttonStyles,

--- a/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
@@ -1,0 +1,107 @@
+import { Button as MuiButton } from '@mui/material'
+import React, { useCallback, useMemo } from 'react'
+
+import { grey, primary } from '@/theme/palette'
+
+const SIZE_STYLES: Record<'small' | 'regular', React.CSSProperties> = {
+  small: {
+    width: '160px',
+    minHeight: '36px',
+    padding: '8px 12px',
+    fontSize: '14px',
+    lineHeight: '20px',
+  },
+  regular: {
+    width: '180px',
+    minHeight: '44px',
+    padding: '10px 16px',
+    fontSize: '15px',
+    lineHeight: '20px',
+  },
+}
+
+export interface RcSesSegmentOption {
+  id: string
+  label: string
+  disabled?: boolean
+}
+
+export interface RcSesSegmentButtonProps {
+  option: RcSesSegmentOption
+  isSelected: boolean
+  isFocused: boolean
+  size: 'small' | 'regular'
+  ariaRole: 'tab' | 'radio'
+  onClick: (optionId: string) => void
+  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void
+  onFocus: () => void
+}
+
+const RcSesSegmentButton = React.forwardRef<HTMLButtonElement, RcSesSegmentButtonProps>(
+  (
+    { option, isSelected, isFocused, size, ariaRole, onClick, onKeyDown, onFocus },
+    ref,
+  ) => {
+    const isDisabled = option.disabled
+    const sizeStyles = SIZE_STYLES[size]
+
+    const textColor = useMemo(() => {
+      if (isDisabled) return `${grey['500']} !important`
+      if (isSelected) return `${grey['900']} !important`
+      return `${primary['700']} !important`
+    }, [isDisabled, isSelected])
+
+    const buttonStyles = useMemo(
+      () =>
+        ({
+          flex: '0 1 auto',
+          minWidth: '0',
+          height: 'auto',
+          wordBreak: 'break-word',
+          fontFamily: '"Public Sans", sans-serif !important',
+          border: `2px solid ${isFocused && !isDisabled ? primary['500'] : 'transparent'}`,
+          backgroundColor: isSelected
+            ? `${primary['50']} !important`
+            : 'transparent !important',
+          color: textColor,
+          cursor: isDisabled ? 'not-allowed' : 'pointer',
+          fontWeight: 500,
+          borderRadius: '8px',
+          transition: 'all 150ms ease-in-out',
+          whiteSpace: 'normal',
+          outline: 'none',
+          ...sizeStyles,
+        }) as React.CSSProperties,
+      [sizeStyles, isDisabled, isSelected, isFocused, textColor],
+    )
+
+    const handleClick = useCallback(() => {
+      onClick(option.id)
+    }, [option.id, onClick])
+
+    return (
+      <MuiButton
+        ref={ref}
+        type='button'
+        onClick={handleClick}
+        onKeyDown={onKeyDown}
+        onFocus={onFocus}
+        disabled={isDisabled}
+        role={ariaRole}
+        aria-checked={isSelected}
+        aria-selected={isSelected}
+        tabIndex={isFocused && !isDisabled ? 0 : -1}
+        sx={{
+          ...buttonStyles,
+          '&.Mui-disabled': {
+            backgroundColor: 'transparent !important',
+          },
+        }}
+      >
+        {option.label}
+      </MuiButton>
+    )
+  },
+)
+
+export default RcSesSegmentButton

--- a/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
@@ -6,6 +6,7 @@ import { grey, primary } from '@/theme/palette'
 const SIZE_STYLES: Record<'small' | 'regular', React.CSSProperties> = {
   small: {
     width: 'auto',
+    maxWidth: '160px',
     minHeight: '36px',
     padding: '8px 12px',
     fontSize: '14px',
@@ -13,6 +14,7 @@ const SIZE_STYLES: Record<'small' | 'regular', React.CSSProperties> = {
   },
   regular: {
     width: 'auto',
+    maxWidth: '180px',
     minHeight: '44px',
     padding: '10px 16px',
     fontSize: '15px',

--- a/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
+++ b/src/components/common/SegmentedControl/components/SegmentButton/index.tsx
@@ -72,7 +72,6 @@ const RcSesSegmentButton = React.forwardRef<HTMLButtonElement, RcSesSegmentButto
           borderRadius: '8px',
           transition: 'all 150ms ease-in-out',
           whiteSpace: 'normal',
-          outline: 'none',
           ...sizeStyles,
         }) as React.CSSProperties,
       [sizeStyles, isDisabled, isSelected, isFocused, textColor],

--- a/src/components/common/SegmentedControl/index.test.tsx
+++ b/src/components/common/SegmentedControl/index.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+
+import RcSesSegmentedControl, { type RcSesSegmentOption } from './index'
+
+describe('RcSesSegmentedControl', () => {
+  const options: RcSesSegmentOption[] = [
+    { id: 'option-1', label: 'Option 1', disabled: false },
+    { id: 'option-2', label: 'Option 2', disabled: false },
+    { id: 'option-3', label: 'Option 3', disabled: false },
+  ]
+
+  const defaultProps = {
+    options,
+    value: 'option-1',
+    onChange: vi.fn(),
+  }
+
+  test('renders all options', () => {
+    render(<RcSesSegmentedControl {...defaultProps} />)
+
+    expect(screen.getByRole('radio', { name: 'Option 1' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Option 2' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Option 3' })).toBeInTheDocument()
+  })
+
+  test('has correct container role (radiogroup by default)', () => {
+    render(<RcSesSegmentedControl {...defaultProps} />)
+
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument()
+  })
+
+  test('marks selected option wtesth aria-checked=true', () => {
+    render(<RcSesSegmentedControl {...defaultProps} value='option-2' />)
+
+    expect(screen.getByRole('radio', { name: 'Option 2' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+  })
+
+  test('calls onChange when option clicked', () => {
+    const onChange = vi.fn()
+    render(<RcSesSegmentedControl {...defaultProps} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Option 2' }))
+    expect(onChange).toHaveBeenCalledWith('option-2')
+  })
+
+  test('navigates wtesth ArrowRight key', () => {
+    const onChange = vi.fn()
+    render(<RcSesSegmentedControl {...defaultProps} onChange={onChange} />)
+
+    const option1 = screen.getByRole('radio', { name: 'Option 1' })
+    fireEvent.keyDown(option1, { key: 'ArrowRight' })
+
+    expect(option1).toBeInTheDocument()
+  })
+
+  test('jumps to first/last option wtesth Home/End keys', () => {
+    render(<RcSesSegmentedControl {...defaultProps} value='option-2' />)
+
+    const option2 = screen.getByRole('radio', { name: 'Option 2' })
+    fireEvent.keyDown(option2, { key: 'Home' })
+
+    expect(screen.getByRole('radio', { name: 'Option 1' })).toBeInTheDocument()
+  })
+
+  test('selects option wtesth Enter key', () => {
+    const onChange = vi.fn()
+    render(
+      <RcSesSegmentedControl {...defaultProps} onChange={onChange} value='option-1' />,
+    )
+
+    const option2 = screen.getByRole('radio', { name: 'Option 2' })
+    fireEvent.focus(option2)
+    fireEvent.keyDown(option2, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledWith('option-2')
+  })
+
+  test('selects option wtesth Space key', () => {
+    const onChange = vi.fn()
+    render(
+      <RcSesSegmentedControl {...defaultProps} onChange={onChange} value='option-1' />,
+    )
+
+    const option2 = screen.getByRole('radio', { name: 'Option 2' })
+    fireEvent.keyDown(option2, { key: ' ' })
+
+    expect(onChange).toHaveBeenCalledWith('option-2')
+  })
+
+  test('skips disabled options in navigation', () => {
+    const optionsWtesthDisabled: RcSesSegmentOption[] = [
+      { id: 'option-1', label: 'Option 1', disabled: false },
+      { id: 'option-2', label: 'Option 2', disabled: true },
+      { id: 'option-3', label: 'Option 3', disabled: false },
+    ]
+
+    render(
+      <RcSesSegmentedControl
+        options={optionsWtesthDisabled}
+        value='option-1'
+        onChange={vi.fn()}
+      />,
+    )
+
+    const option1 = screen.getByRole('radio', { name: 'Option 1' })
+    fireEvent.keyDown(option1, { key: 'ArrowRight' })
+
+    expect(screen.getByRole('radio', { name: 'Option 3' })).toBeInTheDocument()
+  })
+
+  test('disables disabled options', () => {
+    const optionsWtesthDisabled: RcSesSegmentOption[] = [
+      { id: 'option-1', label: 'Option 1', disabled: false },
+      { id: 'option-2', label: 'Option 2', disabled: true },
+    ]
+
+    render(
+      <RcSesSegmentedControl
+        options={optionsWtesthDisabled}
+        value='option-1'
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('radio', { name: 'Option 2' })).toBeDisabled()
+  })
+
+  test('supports tab role wtesth tab buttons', () => {
+    render(<RcSesSegmentedControl {...defaultProps} role='tablist' />)
+
+    expect(screen.getByRole('tab', { name: 'Option 1' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Option 2' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Option 3' })).toBeInTheDocument()
+  })
+
+  test('updates selected option when value prop changes', () => {
+    const { rerender } = render(
+      <RcSesSegmentedControl {...defaultProps} value='option-1' />,
+    )
+
+    expect(screen.getByRole('radio', { name: 'Option 1' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+
+    rerender(<RcSesSegmentedControl {...defaultProps} value='option-2' />)
+
+    expect(screen.getByRole('radio', { name: 'Option 2' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+  })
+})

--- a/src/components/common/SegmentedControl/index.test.tsx
+++ b/src/components/common/SegmentedControl/index.test.tsx
@@ -30,7 +30,7 @@ describe('RcSesSegmentedControl', () => {
     expect(screen.getByRole('radiogroup')).toBeInTheDocument()
   })
 
-  test('marks selected option wtesth aria-checked=true', () => {
+  test('marks selected option with aria-checked=true', () => {
     render(<RcSesSegmentedControl {...defaultProps} value='option-2' />)
 
     expect(screen.getByRole('radio', { name: 'Option 2' })).toHaveAttribute(
@@ -47,26 +47,31 @@ describe('RcSesSegmentedControl', () => {
     expect(onChange).toHaveBeenCalledWith('option-2')
   })
 
-  test('navigates wtesth ArrowRight key', () => {
+  test('navigates with ArrowRight key', () => {
     const onChange = vi.fn()
     render(<RcSesSegmentedControl {...defaultProps} onChange={onChange} />)
 
     const option1 = screen.getByRole('radio', { name: 'Option 1' })
     fireEvent.keyDown(option1, { key: 'ArrowRight' })
 
-    expect(option1).toBeInTheDocument()
+    expect(onChange).toHaveBeenCalledWith('option-2')
+    expect(screen.getByRole('radio', { name: 'Option 2' })).toHaveFocus()
   })
 
-  test('jumps to first/last option wtesth Home/End keys', () => {
-    render(<RcSesSegmentedControl {...defaultProps} value='option-2' />)
+  test('jumps to first/last option with Home/End keys', () => {
+    const onChange = vi.fn()
+    render(
+      <RcSesSegmentedControl {...defaultProps} onChange={onChange} value='option-2' />,
+    )
 
     const option2 = screen.getByRole('radio', { name: 'Option 2' })
     fireEvent.keyDown(option2, { key: 'Home' })
 
-    expect(screen.getByRole('radio', { name: 'Option 1' })).toBeInTheDocument()
+    expect(onChange).toHaveBeenCalledWith('option-1')
+    expect(screen.getByRole('radio', { name: 'Option 1' })).toHaveFocus()
   })
 
-  test('selects option wtesth Enter key', () => {
+  test('selects option with Enter key', () => {
     const onChange = vi.fn()
     render(
       <RcSesSegmentedControl {...defaultProps} onChange={onChange} value='option-1' />,
@@ -79,7 +84,7 @@ describe('RcSesSegmentedControl', () => {
     expect(onChange).toHaveBeenCalledWith('option-2')
   })
 
-  test('selects option wtesth Space key', () => {
+  test('selects option with Space key', () => {
     const onChange = vi.fn()
     render(
       <RcSesSegmentedControl {...defaultProps} onChange={onChange} value='option-1' />,
@@ -92,7 +97,8 @@ describe('RcSesSegmentedControl', () => {
   })
 
   test('skips disabled options in navigation', () => {
-    const optionsWtesthDisabled: RcSesSegmentOption[] = [
+    const onChange = vi.fn()
+    const optionsWithDisabled: RcSesSegmentOption[] = [
       { id: 'option-1', label: 'Option 1', disabled: false },
       { id: 'option-2', label: 'Option 2', disabled: true },
       { id: 'option-3', label: 'Option 3', disabled: false },
@@ -100,27 +106,28 @@ describe('RcSesSegmentedControl', () => {
 
     render(
       <RcSesSegmentedControl
-        options={optionsWtesthDisabled}
+        options={optionsWithDisabled}
         value='option-1'
-        onChange={vi.fn()}
+        onChange={onChange}
       />,
     )
 
     const option1 = screen.getByRole('radio', { name: 'Option 1' })
     fireEvent.keyDown(option1, { key: 'ArrowRight' })
 
-    expect(screen.getByRole('radio', { name: 'Option 3' })).toBeInTheDocument()
+    expect(onChange).toHaveBeenCalledWith('option-3')
+    expect(screen.getByRole('radio', { name: 'Option 3' })).toHaveFocus()
   })
 
   test('disables disabled options', () => {
-    const optionsWtesthDisabled: RcSesSegmentOption[] = [
+    const optionsWithDisabled: RcSesSegmentOption[] = [
       { id: 'option-1', label: 'Option 1', disabled: false },
       { id: 'option-2', label: 'Option 2', disabled: true },
     ]
 
     render(
       <RcSesSegmentedControl
-        options={optionsWtesthDisabled}
+        options={optionsWithDisabled}
         value='option-1'
         onChange={vi.fn()}
       />,
@@ -129,7 +136,7 @@ describe('RcSesSegmentedControl', () => {
     expect(screen.getByRole('radio', { name: 'Option 2' })).toBeDisabled()
   })
 
-  test('supports tab role wtesth tab buttons', () => {
+  test('supports tab role with tab buttons', () => {
     render(<RcSesSegmentedControl {...defaultProps} role='tablist' />)
 
     expect(screen.getByRole('tab', { name: 'Option 1' })).toBeInTheDocument()

--- a/src/components/common/SegmentedControl/index.tsx
+++ b/src/components/common/SegmentedControl/index.tsx
@@ -47,6 +47,11 @@ const RcSesSegmentedControl = React.forwardRef<
 
     useImperativeHandle(ref, () => containerRef.current as HTMLDivElement)
 
+    React.useEffect(() => {
+      const selectedIndex = options.findIndex((opt) => opt.id === value && !opt.disabled)
+      if (selectedIndex !== -1) setFocusIndex(selectedIndex)
+    }, [value, options])
+
     const getEnabledIndices = useCallback(
       () => options.map((opt, i) => (!opt.disabled ? i : -1)).filter((i) => i !== -1),
       [options],

--- a/src/components/common/SegmentedControl/index.tsx
+++ b/src/components/common/SegmentedControl/index.tsx
@@ -1,0 +1,147 @@
+import React, { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
+
+import { grey } from '@/theme/palette'
+
+import RcSesSegmentButton, { type RcSesSegmentOption } from './components/SegmentButton'
+
+export type { RcSesSegmentOption }
+
+export interface RcSesSegmentedControlProps {
+  options: RcSesSegmentOption[]
+  value: string
+  onChange: (value: string) => void
+  size?: 'small' | 'regular'
+  role?: 'radiogroup' | 'tablist'
+  disableBg?: boolean
+}
+
+const RcSesSegmentedControl = React.forwardRef<
+  HTMLDivElement,
+  RcSesSegmentedControlProps
+>(
+  (
+    {
+      options,
+      value,
+      onChange,
+      size = 'regular',
+      role = 'radiogroup',
+      disableBg = false,
+    },
+    ref,
+  ) => {
+    const [focusIndex, setFocusIndex] = useState(0)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    useImperativeHandle(ref, () => containerRef.current as HTMLDivElement)
+
+    const getEnabledIndices = useCallback(
+      () => options.map((opt, i) => (!opt.disabled ? i : -1)).filter((i) => i !== -1),
+      [options],
+    )
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+        const enabledIndices = getEnabledIndices()
+        const currentPos = enabledIndices.indexOf(index)
+
+        switch (e.key) {
+          case 'ArrowLeft':
+          case 'ArrowUp': {
+            e.preventDefault()
+            const prevIndex =
+              currentPos > 0
+                ? enabledIndices[currentPos - 1]
+                : enabledIndices[enabledIndices.length - 1]
+            setFocusIndex(prevIndex)
+            break
+          }
+
+          case 'ArrowRight':
+          case 'ArrowDown': {
+            e.preventDefault()
+            const nextIndex =
+              currentPos < enabledIndices.length - 1
+                ? enabledIndices[currentPos + 1]
+                : enabledIndices[0]
+            setFocusIndex(nextIndex)
+            break
+          }
+
+          case 'Home':
+            e.preventDefault()
+            setFocusIndex(enabledIndices[0])
+            break
+
+          case 'End':
+            e.preventDefault()
+            setFocusIndex(enabledIndices[enabledIndices.length - 1])
+            break
+
+          case 'Enter':
+          case ' ':
+            e.preventDefault()
+            onChange(options[index].id)
+            break
+
+          default:
+            break
+        }
+      },
+      [getEnabledIndices, onChange, options],
+    )
+
+    const handleSegmentClick = useCallback(
+      (optionId: string, index: number) => {
+        onChange(optionId)
+        setFocusIndex(index)
+      },
+      [onChange],
+    )
+
+    const handleFocus = useCallback((index: number) => {
+      setFocusIndex(index)
+    }, [])
+
+    const isSelected = useCallback((optionId: string) => value === optionId, [value])
+    const ariaRole = role === 'tablist' ? 'tab' : 'radio'
+
+    const containerStyles = useMemo<React.CSSProperties>(
+      () => ({
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '2px 8px',
+        padding: '4px',
+        backgroundColor: disableBg ? 'transparent' : grey['50'],
+        width: 'fit-content',
+        borderRadius: '8px',
+      }),
+      [disableBg],
+    )
+
+    return (
+      <div
+        ref={containerRef}
+        role={role}
+        aria-label='Segmented control options'
+        style={containerStyles}
+      >
+        {options.map((option, index) => (
+          <RcSesSegmentButton
+            key={option.id}
+            option={option}
+            isSelected={isSelected(option.id)}
+            isFocused={focusIndex === index && !option.disabled}
+            size={size}
+            ariaRole={ariaRole}
+            onClick={(optionId) => handleSegmentClick(optionId, index)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            onFocus={() => handleFocus(index)}
+          />
+        ))}
+      </div>
+    )
+  },
+)
+
+export default RcSesSegmentedControl

--- a/src/components/common/SegmentedControl/index.tsx
+++ b/src/components/common/SegmentedControl/index.tsx
@@ -13,6 +13,7 @@ export interface RcSesSegmentedControlProps {
   size?: 'small' | 'regular'
   role?: 'radiogroup' | 'tablist'
   disableBg?: boolean
+  ariaLabel?: string
 }
 
 const RcSesSegmentedControl = React.forwardRef<
@@ -27,11 +28,17 @@ const RcSesSegmentedControl = React.forwardRef<
       size = 'regular',
       role = 'radiogroup',
       disableBg = false,
+      ariaLabel,
     },
     ref,
   ) => {
-    const [focusIndex, setFocusIndex] = useState(0)
+    const [focusIndex, setFocusIndex] = useState(() => {
+      const selectedIndex = options.findIndex((opt) => opt.id === value && !opt.disabled)
+      if (selectedIndex !== -1) return selectedIndex
+      return Math.max(0, options.findIndex((opt) => !opt.disabled))
+    })
     const containerRef = useRef<HTMLDivElement>(null)
+    const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
 
     useImperativeHandle(ref, () => containerRef.current as HTMLDivElement)
 
@@ -39,6 +46,11 @@ const RcSesSegmentedControl = React.forwardRef<
       () => options.map((opt, i) => (!opt.disabled ? i : -1)).filter((i) => i !== -1),
       [options],
     )
+
+    const focusSegment = useCallback((index: number) => {
+      setFocusIndex(index)
+      buttonRefs.current[index]?.focus()
+    }, [])
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
@@ -53,7 +65,8 @@ const RcSesSegmentedControl = React.forwardRef<
               currentPos > 0
                 ? enabledIndices[currentPos - 1]
                 : enabledIndices[enabledIndices.length - 1]
-            setFocusIndex(prevIndex)
+            focusSegment(prevIndex)
+            onChange(options[prevIndex].id)
             break
           }
 
@@ -64,19 +77,26 @@ const RcSesSegmentedControl = React.forwardRef<
               currentPos < enabledIndices.length - 1
                 ? enabledIndices[currentPos + 1]
                 : enabledIndices[0]
-            setFocusIndex(nextIndex)
+            focusSegment(nextIndex)
+            onChange(options[nextIndex].id)
             break
           }
 
-          case 'Home':
+          case 'Home': {
             e.preventDefault()
-            setFocusIndex(enabledIndices[0])
+            const firstIndex = enabledIndices[0]
+            focusSegment(firstIndex)
+            onChange(options[firstIndex].id)
             break
+          }
 
-          case 'End':
+          case 'End': {
             e.preventDefault()
-            setFocusIndex(enabledIndices[enabledIndices.length - 1])
+            const lastIndex = enabledIndices[enabledIndices.length - 1]
+            focusSegment(lastIndex)
+            onChange(options[lastIndex].id)
             break
+          }
 
           case 'Enter':
           case ' ':
@@ -88,7 +108,7 @@ const RcSesSegmentedControl = React.forwardRef<
             break
         }
       },
-      [getEnabledIndices, onChange, options],
+      [focusSegment, getEnabledIndices, onChange, options],
     )
 
     const handleSegmentClick = useCallback(
@@ -123,12 +143,15 @@ const RcSesSegmentedControl = React.forwardRef<
       <div
         ref={containerRef}
         role={role}
-        aria-label='Segmented control options'
+        aria-label={ariaLabel}
         style={containerStyles}
       >
         {options.map((option, index) => (
           <RcSesSegmentButton
             key={option.id}
+            ref={(el) => {
+              buttonRefs.current[index] = el
+            }}
             option={option}
             isSelected={isSelected(option.id)}
             isFocused={focusIndex === index && !option.disabled}

--- a/src/components/common/SegmentedControl/index.tsx
+++ b/src/components/common/SegmentedControl/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { grey } from '@/theme/palette'
 
@@ -32,6 +33,7 @@ const RcSesSegmentedControl = React.forwardRef<
     },
     ref,
   ) => {
+    const { t } = useTranslation('common')
     const [focusIndex, setFocusIndex] = useState(() => {
       const selectedIndex = options.findIndex((opt) => opt.id === value && !opt.disabled)
       if (selectedIndex !== -1) return selectedIndex
@@ -128,6 +130,14 @@ const RcSesSegmentedControl = React.forwardRef<
 
     const isSelected = useCallback((optionId: string) => value === optionId, [value])
     const ariaRole = role === 'tablist' ? 'tab' : 'radio'
+    const defaultAriaLabel =
+      ariaLabel ||
+      t(
+        role === 'tablist'
+          ? 'components.SegmentedControl.tabs'
+          : 'components.SegmentedControl.options',
+      )
+    const finalAriaLabel = defaultAriaLabel
 
     const containerStyles = useMemo<React.CSSProperties>(
       () => ({
@@ -143,7 +153,12 @@ const RcSesSegmentedControl = React.forwardRef<
     )
 
     return (
-      <div ref={containerRef} role={role} aria-label={ariaLabel} style={containerStyles}>
+      <div
+        ref={containerRef}
+        role={role}
+        aria-label={finalAriaLabel}
+        style={containerStyles}
+      >
         {options.map((option, index) => (
           <RcSesSegmentButton
             key={option.id}

--- a/src/components/common/SegmentedControl/index.tsx
+++ b/src/components/common/SegmentedControl/index.tsx
@@ -35,7 +35,10 @@ const RcSesSegmentedControl = React.forwardRef<
     const [focusIndex, setFocusIndex] = useState(() => {
       const selectedIndex = options.findIndex((opt) => opt.id === value && !opt.disabled)
       if (selectedIndex !== -1) return selectedIndex
-      return Math.max(0, options.findIndex((opt) => !opt.disabled))
+      return Math.max(
+        0,
+        options.findIndex((opt) => !opt.disabled),
+      )
     })
     const containerRef = useRef<HTMLDivElement>(null)
     const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
@@ -140,12 +143,7 @@ const RcSesSegmentedControl = React.forwardRef<
     )
 
     return (
-      <div
-        ref={containerRef}
-        role={role}
-        aria-label={ariaLabel}
-        style={containerStyles}
-      >
+      <div ref={containerRef} role={role} aria-label={ariaLabel} style={containerStyles}>
         {options.map((option, index) => (
           <RcSesSegmentButton
             key={option.id}

--- a/src/i18n/namespaces/common/en.json
+++ b/src/i18n/namespaces/common/en.json
@@ -10,6 +10,10 @@
     },
     "Button": {
       "loading": "Loading"
+    },
+    "SegmentedControl": {
+      "options": "Options",
+      "tabs": "Tabs"
     }
   }
 }

--- a/src/i18n/namespaces/common/lt.json
+++ b/src/i18n/namespaces/common/lt.json
@@ -10,6 +10,10 @@
     },
     "Button": {
       "loading": "Kraunasi"
+    },
+    "SegmentedControl": {
+      "options": "Parinktys",
+      "tabs": "Skirtukai"
     }
   }
 }

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -14,6 +14,7 @@ import DataPagination from '@/components/common/DataPagination'
 import RcSesIconWithCircularBackground from '@/components/common/IconWithCircularBackground'
 import RcSesImageCard from '@/components/common/ImageCard'
 import ListWithIcons from '@/components/common/ListWithIcons'
+import RcSesSegmentedControl from '@/components/common/SegmentedControl'
 import RcSesSnackbar from '@/components/common/Snackbar'
 import {
   RcSesSnackbarProvider,
@@ -80,6 +81,7 @@ export {
   RcSesSnackbarProvider,
   RcSesModal,
 }
+export { RcSesSegmentedControl }
 export { RcSesCheckbox, RcSesCheckboxFormControl, RcSesSimpleCheckbox }
 export { useSnackbar }
 export { RcSesDatepicker }

--- a/src/library/types.ts
+++ b/src/library/types.ts
@@ -1,6 +1,11 @@
 import { RcSesCardProps } from '@/components/common/Card'
 import { ListWithIconsProps } from '@/components/common/ListWithIcons'
 import { ListWithIconsItemData } from '@/components/common/ListWithIcons/ListWithIcons.types'
+import {
+  RcSesSegmentOption,
+  RcSesSegmentedControlProps,
+} from '@/components/common/SegmentedControl'
+import { RcSesSegmentButtonProps } from '@/components/common/SegmentedControl/components/SegmentButton'
 import { RcSesFormControlLabelProps } from '@/components/form/inputs/FormControlLabel'
 import { SimpleCheckboxProps } from '@/components/form/inputs/SimpleCheckbox'
 import { RcSesCardFormContainerProps } from '@/components/layout/ServiceFormContainer/CardFormContainer'
@@ -28,6 +33,9 @@ export type {
   RcSesLoaderSize,
   RcSesCardFormContainerProps,
   RcSesCardProps,
+  RcSesSegmentedControlProps,
+  RcSesSegmentButtonProps,
+  RcSesSegmentOption,
   ServiceWizardStepperProps,
   SimpleCheckboxProps,
   RcSesFormControlLabelProps,

--- a/src/stories/components/display/SegmentedControl.stories.tsx
+++ b/src/stories/components/display/SegmentedControl.stories.tsx
@@ -91,27 +91,16 @@ export const Default = {
   ),
 } as const
 
-const RegularTwoOptionsComponent = () => {
-  const [value, setValue] = useState('1')
-  return (
-    <RcSesSegmentedControl
-      options={[
-        { id: '1', label: 'Fizinis asmuo' },
-        { id: '2', label: 'Juridinis asmuo' },
-      ]}
-      value={value}
-      onChange={(newValue) => {
-        // eslint-disable-next-line no-console
-        console.log('RegularTwoOptions - Selected value:', newValue)
-        setValue(newValue)
-      }}
-      size='regular'
-    />
-  )
-}
-
 export const RegularTwoOptions = {
-  render: () => <RegularTwoOptionsComponent />,
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo' },
+    ],
+    value: '1',
+    size: 'regular',
+  },
+  render: (args: any) => <DefaultComponent {...args} />,
   parameters: {
     docs: {
       source: {
@@ -131,29 +120,18 @@ export const RegularTwoOptions = {
   },
 } as const
 
-const RegularFourOptionsComponent = () => {
-  const [value, setValue] = useState('1')
-  return (
-    <RcSesSegmentedControl
-      options={[
-        { id: '1', label: 'Fizinis asmuo' },
-        { id: '2', label: 'Juridinis asmuo' },
-        { id: '3', label: 'Advokatas' },
-        { id: '4', label: 'Labai ilgas tekstas, netelpantis į vieną eilutę' },
-      ]}
-      value={value}
-      onChange={(newValue) => {
-        // eslint-disable-next-line no-console
-        console.log('RegularFourOptions - Selected value:', newValue)
-        setValue(newValue)
-      }}
-      size='regular'
-    />
-  )
-}
-
 export const RegularFourOptions = {
-  render: () => <RegularFourOptionsComponent />,
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo' },
+      { id: '3', label: 'Advokatas' },
+      { id: '4', label: 'Labai ilgas tekstas, netelpantis į vieną eilutę' },
+    ],
+    value: '1',
+    size: 'regular',
+  },
+  render: (args: any) => <DefaultComponent {...args} />,
   parameters: {
     docs: {
       source: {
@@ -175,28 +153,17 @@ export const RegularFourOptions = {
   },
 }
 
-const RegularWithDisabledComponent = () => {
-  const [value, setValue] = useState('1')
-  return (
-    <RcSesSegmentedControl
-      options={[
-        { id: '1', label: 'Fizinis asmuo' },
-        { id: '2', label: 'Juridinis asmuo (Disabled)', disabled: true },
-        { id: '3', label: 'Advokatas' },
-      ]}
-      value={value}
-      onChange={(newValue) => {
-        // eslint-disable-next-line no-console
-        console.log('RegularWithDisabled - Selected value:', newValue)
-        setValue(newValue)
-      }}
-      size='regular'
-    />
-  )
-}
-
 export const RegularWithDisabled = {
-  render: () => <RegularWithDisabledComponent />,
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo (Disabled)', disabled: true },
+      { id: '3', label: 'Advokatas' },
+    ],
+    value: '1',
+    size: 'regular',
+  },
+  render: (args: any) => <DefaultComponent {...args} />,
   parameters: {
     docs: {
       source: {
@@ -217,27 +184,16 @@ export const RegularWithDisabled = {
   },
 }
 
-const SmallTwoOptionsComponent = () => {
-  const [value, setValue] = useState('1')
-  return (
-    <RcSesSegmentedControl
-      options={[
-        { id: '1', label: 'Fizinis asmuo' },
-        { id: '2', label: 'Juridinis asmuo' },
-      ]}
-      value={value}
-      onChange={(newValue) => {
-        // eslint-disable-next-line no-console
-        console.log('SmallTwoOptions - Selected value:', newValue)
-        setValue(newValue)
-      }}
-      size='small'
-    />
-  )
-}
-
 export const SmallTwoOptions = {
-  render: () => <SmallTwoOptionsComponent />,
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo' },
+    ],
+    value: '1',
+    size: 'small',
+  },
+  render: (args: any) => <DefaultComponent {...args} />,
   parameters: {
     docs: {
       source: {
@@ -257,29 +213,18 @@ export const SmallTwoOptions = {
   },
 } as const
 
-const SmallFourOptionsComponent = () => {
-  const [value, setValue] = useState('1')
-  return (
-    <RcSesSegmentedControl
-      options={[
-        { id: '1', label: 'Fizinis asmuo' },
-        { id: '2', label: 'Juridinis asmuo' },
-        { id: '3', label: 'Advokatas' },
-        { id: '4', label: 'Kita' },
-      ]}
-      value={value}
-      onChange={(newValue) => {
-        // eslint-disable-next-line no-console
-        console.log('SmallFourOptions - Selected value:', newValue)
-        setValue(newValue)
-      }}
-      size='small'
-    />
-  )
-}
-
 export const SmallFourOptions = {
-  render: () => <SmallFourOptionsComponent />,
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo' },
+      { id: '3', label: 'Advokatas' },
+      { id: '4', label: 'Kita' },
+    ],
+    value: '1',
+    size: 'small',
+  },
+  render: (args: any) => <DefaultComponent {...args} />,
   parameters: {
     docs: {
       source: {
@@ -301,28 +246,17 @@ export const SmallFourOptions = {
   },
 }
 
-const SmallWithDisabledComponent = () => {
-  const [value, setValue] = useState('1')
-  return (
-    <RcSesSegmentedControl
-      options={[
-        { id: '1', label: 'Fizinis asmuo' },
-        { id: '2', label: 'Juridinis asmuo (Disabled)', disabled: true },
-        { id: '3', label: 'Advokatas' },
-      ]}
-      value={value}
-      onChange={(newValue) => {
-        // eslint-disable-next-line no-console
-        console.log('SmallWithDisabled - Selected value:', newValue)
-        setValue(newValue)
-      }}
-      size='small'
-    />
-  )
-}
-
 export const SmallWithDisabled = {
-  render: () => <SmallWithDisabledComponent />,
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo (Disabled)', disabled: true },
+      { id: '3', label: 'Advokatas' },
+    ],
+    value: '1',
+    size: 'small',
+  },
+  render: (args: any) => <DefaultComponent {...args} />,
   parameters: {
     docs: {
       source: {
@@ -343,29 +277,18 @@ export const SmallWithDisabled = {
   },
 }
 
-const RegularNoBackgroundComponent = () => {
-  const [value, setValue] = useState('1')
-  return (
-    <RcSesSegmentedControl
-      options={[
-        { id: '1', label: 'Fizinis asmuo' },
-        { id: '2', label: 'Juridinis asmuo' },
-        { id: '3', label: 'Advokatas' },
-      ]}
-      value={value}
-      onChange={(newValue) => {
-        // eslint-disable-next-line no-console
-        console.log('RegularNoBackground - Selected value:', newValue)
-        setValue(newValue)
-      }}
-      size='regular'
-      disableBg
-    />
-  )
-}
-
 export const RegularNoBackground = {
-  render: () => <RegularNoBackgroundComponent />,
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo' },
+      { id: '3', label: 'Advokatas' },
+    ],
+    value: '1',
+    size: 'regular',
+    disableBg: true,
+  },
+  render: (args: any) => <DefaultComponent {...args} />,
   parameters: {
     docs: {
       source: {

--- a/src/stories/components/display/SegmentedControl.stories.tsx
+++ b/src/stories/components/display/SegmentedControl.stories.tsx
@@ -1,0 +1,388 @@
+import type { Meta } from '@storybook/react'
+import { useState } from 'react'
+
+import RcSesSegmentedControl from '../../../components/common/SegmentedControl'
+
+const meta = {
+  title: 'components/display/SegmentedControl',
+  component: RcSesSegmentedControl,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    options: {
+      control: false,
+      description: 'Array of options to display',
+    },
+    value: {
+      control: 'text',
+      description: 'Currently selected option ID',
+    },
+    onChange: {
+      control: false,
+      description: 'Callback when selection changes',
+    },
+    size: {
+      control: 'radio',
+      options: ['small', 'regular'],
+      description: 'Size of the segmented control',
+    },
+    role: {
+      control: 'radio',
+      options: ['radiogroup', 'tablist'],
+      description: 'ARIA role for accessibility',
+    },
+    disableBg: {
+      control: 'boolean',
+      description: 'Disable container background',
+    },
+  },
+} satisfies Meta<typeof RcSesSegmentedControl>
+
+export default meta
+
+const DefaultComponent = ({
+  options,
+  value: initialValue,
+  onChange,
+  size,
+  role,
+  disableBg,
+}: any) => {
+  const [value, setValue] = useState(initialValue)
+  return (
+    <RcSesSegmentedControl
+      options={options}
+      value={value}
+      onChange={(newValue) => {
+        setValue(newValue)
+        onChange?.(newValue)
+      }}
+      size={size}
+      role={role}
+      disableBg={disableBg}
+    />
+  )
+}
+
+export const Default = {
+  args: {
+    options: [
+      { id: '1', label: 'Fizinis asmuo' },
+      { id: '2', label: 'Juridinis asmuo' },
+      { id: '3', label: 'Advokatas' },
+    ],
+    value: '1',
+    onChange: () => {},
+    size: 'regular' as const,
+    role: 'radiogroup' as const,
+    disableBg: false,
+  },
+  render: ({ options, value: initialValue, onChange, size, role, disableBg }: any) => (
+    <DefaultComponent
+      options={options}
+      value={initialValue}
+      onChange={onChange}
+      size={size}
+      role={role}
+      disableBg={disableBg}
+    />
+  ),
+} as const
+
+const RegularTwoOptionsComponent = () => {
+  const [value, setValue] = useState('1')
+  return (
+    <RcSesSegmentedControl
+      options={[
+        { id: '1', label: 'Fizinis asmuo' },
+        { id: '2', label: 'Juridinis asmuo' },
+      ]}
+      value={value}
+      onChange={(newValue) => {
+        // eslint-disable-next-line no-console
+        console.log('RegularTwoOptions - Selected value:', newValue)
+        setValue(newValue)
+      }}
+      size='regular'
+    />
+  )
+}
+
+export const RegularTwoOptions = {
+  render: () => <RegularTwoOptionsComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState('1');
+
+<RcSesSegmentedControl
+  options={[
+    { id: '1', label: 'Fizinis asmuo' },
+    { id: '2', label: 'Juridinis asmuo' },
+  ]}
+  value={value}
+  onChange={(newValue) => setValue(newValue)}
+  size="regular"
+/>`,
+      },
+    },
+  },
+} as const
+
+const RegularFourOptionsComponent = () => {
+  const [value, setValue] = useState('1')
+  return (
+    <RcSesSegmentedControl
+      options={[
+        { id: '1', label: 'Fizinis asmuo' },
+        { id: '2', label: 'Juridinis asmuo' },
+        { id: '3', label: 'Advokatas' },
+        { id: '4', label: 'Labai ilgas tekstas, netelpantis į vieną eilutę' },
+      ]}
+      value={value}
+      onChange={(newValue) => {
+        // eslint-disable-next-line no-console
+        console.log('RegularFourOptions - Selected value:', newValue)
+        setValue(newValue)
+      }}
+      size='regular'
+    />
+  )
+}
+
+export const RegularFourOptions = {
+  render: () => <RegularFourOptionsComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState('1');
+
+<RcSesSegmentedControl
+  options={[
+    { id: '1', label: 'Fizinis asmuo' },
+    { id: '2', label: 'Juridinis asmuo' },
+    { id: '3', label: 'Advokatas' },
+    { id: '4', label: 'Labai ilgas tekstas, netelpantis į vieną eilutę' },
+  ]}
+  value={value}
+  onChange={(newValue) => setValue(newValue)}
+  size="regular"
+/>`,
+      },
+    },
+  },
+}
+
+const RegularWithDisabledComponent = () => {
+  const [value, setValue] = useState('1')
+  return (
+    <RcSesSegmentedControl
+      options={[
+        { id: '1', label: 'Fizinis asmuo' },
+        { id: '2', label: 'Juridinis asmuo (Disabled)', disabled: true },
+        { id: '3', label: 'Advokatas' },
+      ]}
+      value={value}
+      onChange={(newValue) => {
+        // eslint-disable-next-line no-console
+        console.log('RegularWithDisabled - Selected value:', newValue)
+        setValue(newValue)
+      }}
+      size='regular'
+    />
+  )
+}
+
+export const RegularWithDisabled = {
+  render: () => <RegularWithDisabledComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState('1');
+
+<RcSesSegmentedControl
+  options={[
+    { id: '1', label: 'Fizinis asmuo' },
+    { id: '2', label: 'Juridinis asmuo', disabled: true },
+    { id: '3', label: 'Advokatas' },
+  ]}
+  value={value}
+  onChange={(newValue) => setValue(newValue)}
+  size="regular"
+/>`,
+      },
+    },
+  },
+}
+
+const SmallTwoOptionsComponent = () => {
+  const [value, setValue] = useState('1')
+  return (
+    <RcSesSegmentedControl
+      options={[
+        { id: '1', label: 'Fizinis asmuo' },
+        { id: '2', label: 'Juridinis asmuo' },
+      ]}
+      value={value}
+      onChange={(newValue) => {
+        // eslint-disable-next-line no-console
+        console.log('SmallTwoOptions - Selected value:', newValue)
+        setValue(newValue)
+      }}
+      size='small'
+    />
+  )
+}
+
+export const SmallTwoOptions = {
+  render: () => <SmallTwoOptionsComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState('1');
+
+<RcSesSegmentedControl
+  options={[
+    { id: '1', label: 'Fizinis asmuo' },
+    { id: '2', label: 'Juridinis asmuo' },
+  ]}
+  value={value}
+  onChange={(newValue) => setValue(newValue)}
+  size="small"
+/>`,
+      },
+    },
+  },
+} as const
+
+const SmallFourOptionsComponent = () => {
+  const [value, setValue] = useState('1')
+  return (
+    <RcSesSegmentedControl
+      options={[
+        { id: '1', label: 'Fizinis asmuo' },
+        { id: '2', label: 'Juridinis asmuo' },
+        { id: '3', label: 'Advokatas' },
+        { id: '4', label: 'Kita' },
+      ]}
+      value={value}
+      onChange={(newValue) => {
+        // eslint-disable-next-line no-console
+        console.log('SmallFourOptions - Selected value:', newValue)
+        setValue(newValue)
+      }}
+      size='small'
+    />
+  )
+}
+
+export const SmallFourOptions = {
+  render: () => <SmallFourOptionsComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState('1');
+
+<RcSesSegmentedControl
+  options={[
+    { id: '1', label: 'Fizinis asmuo' },
+    { id: '2', label: 'Juridinis asmuo' },
+    { id: '3', label: 'Advokatas' },
+    { id: '4', label: 'Kita' },
+  ]}
+  value={value}
+  onChange={(newValue) => setValue(newValue)}
+  size="small"
+/>`,
+      },
+    },
+  },
+}
+
+const SmallWithDisabledComponent = () => {
+  const [value, setValue] = useState('1')
+  return (
+    <RcSesSegmentedControl
+      options={[
+        { id: '1', label: 'Fizinis asmuo' },
+        { id: '2', label: 'Juridinis asmuo (Disabled)', disabled: true },
+        { id: '3', label: 'Advokatas' },
+      ]}
+      value={value}
+      onChange={(newValue) => {
+        // eslint-disable-next-line no-console
+        console.log('SmallWithDisabled - Selected value:', newValue)
+        setValue(newValue)
+      }}
+      size='small'
+    />
+  )
+}
+
+export const SmallWithDisabled = {
+  render: () => <SmallWithDisabledComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState('1');
+
+<RcSesSegmentedControl
+  options={[
+    { id: '1', label: 'Fizinis asmuo' },
+    { id: '2', label: 'Juridinis asmuo', disabled: true },
+    { id: '3', label: 'Advokatas' },
+  ]}
+  value={value}
+  onChange={(newValue) => setValue(newValue)}
+  size="small"
+/>`,
+      },
+    },
+  },
+}
+
+const RegularNoBackgroundComponent = () => {
+  const [value, setValue] = useState('1')
+  return (
+    <RcSesSegmentedControl
+      options={[
+        { id: '1', label: 'Fizinis asmuo' },
+        { id: '2', label: 'Juridinis asmuo' },
+        { id: '3', label: 'Advokatas' },
+      ]}
+      value={value}
+      onChange={(newValue) => {
+        // eslint-disable-next-line no-console
+        console.log('RegularNoBackground - Selected value:', newValue)
+        setValue(newValue)
+      }}
+      size='regular'
+      disableBg
+    />
+  )
+}
+
+export const RegularNoBackground = {
+  render: () => <RegularNoBackgroundComponent />,
+  parameters: {
+    docs: {
+      source: {
+        code: `const [value, setValue] = useState('1');
+
+<RcSesSegmentedControl
+  options={[
+    { id: '1', label: 'Fizinis asmuo' },
+    { id: '2', label: 'Juridinis asmuo' },
+    { id: '3', label: 'Advokatas' },
+  ]}
+  value={value}
+  onChange={(newValue) => setValue(newValue)}
+  size="regular"
+  disableBg
+/>`,
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/SAV-6142

<!-- Link the related issue or ticket (e.g., Jira issue) -->

## 🧾 Summary

Added a new `SegmentedControl` component which uses a new `SegmentButton` component. The button has two sizes: `regular` and `small`. `SegmentedControl` component has an option to disable bg color (grey) via `disableBg` prop.

<!-- Brief explanation of what this PR does and why -->

## 📸 Screenshots

It's best to check directly in the Storybook (updated with the latest changes):

https://ses-react-storybook.registrucentras.lt/preview/SAV-6142-add-segmented-control-component/?path=/docs/components-display-segmentedcontrol--docs

<img width="807" height="876" alt="image" src="https://github.com/user-attachments/assets/dd4508ba-c161-4e2c-9494-80b891682805" />

<img width="788" height="503" alt="image" src="https://github.com/user-attachments/assets/f218b107-e718-479a-a170-0643a9cdd745" />


<!-- Visual proof of changes -->

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

N/A, component is not used yet.
<!-- Potential regressions or trade-offs -->
