### PR TITLE
SAV-6111: fix SelectableCardListItem focus issue

### DIFF
--- a/src/components/common/SelectableCardList/components/SelectableCardListItem.test.tsx
+++ b/src/components/common/SelectableCardList/components/SelectableCardListItem.test.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@mui/material/styles'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { type ReactElement } from 'react'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -93,5 +93,80 @@ describe('SelectableCardListItem', () => {
 
     expect(screen.getByText('List entry A')).toBeInTheDocument()
     expect(screen.getByText('List entry B')).toBeInTheDocument()
+  })
+
+  test('calls onSelect once when Enter key is pressed on radio', () => {
+    const onSelect = vi.fn()
+    renderItem(
+      <SelectableCardListItem
+        title='Test'
+        selected={false}
+        onSelect={onSelect}
+        listItems={[]}
+      />,
+    )
+
+    const radio = screen.getByRole('radio')
+    radio.focus()
+    fireEvent.keyDown(radio, { key: 'Enter', code: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  test('calls onSelect once when radio is clicked (no double-call)', () => {
+    const onSelect = vi.fn()
+    renderItem(
+      <SelectableCardListItem
+        title='Test'
+        selected={false}
+        onSelect={onSelect}
+        listItems={[]}
+      />,
+    )
+
+    const radio = screen.getByRole('radio')
+    fireEvent.click(radio)
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  test('calls onSelect once when card is clicked outside radio', () => {
+    const onSelect = vi.fn()
+    renderItem(
+      <SelectableCardListItem
+        title='Test title'
+        selected={false}
+        onSelect={onSelect}
+        listItems={[]}
+      />,
+    )
+
+    // click on the title area (outside the radio)
+    const titleElement = screen.getByRole('heading', { name: 'Test title' })
+    fireEvent.click(titleElement)
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  test('loading card does not call onSelect when clicked', () => {
+    const onSelect = vi.fn()
+    const { container } = renderItem(
+      <SelectableCardListItem
+        title='Loading'
+        selected={false}
+        onSelect={onSelect}
+        isLoading
+        listItems={[]}
+      />,
+    )
+
+    // get the card container and try to click it
+    const cardContent = container.querySelector('[class*="MuiCardContent"]')
+    if (cardContent) {
+      fireEvent.click(cardContent)
+    }
+
+    // should not call onSelect due to pointerEvents: 'none'
+    expect(onSelect).not.toHaveBeenCalled()
   })
 })

--- a/src/components/common/SelectableCardList/components/SelectableCardListItem.test.tsx
+++ b/src/components/common/SelectableCardList/components/SelectableCardListItem.test.tsx
@@ -148,7 +148,7 @@ describe('SelectableCardListItem', () => {
     expect(onSelect).toHaveBeenCalledTimes(1)
   })
 
-  test('loading card does not call onSelect when clicked', () => {
+  test('loading card is not selectable', () => {
     const onSelect = vi.fn()
     const { container } = renderItem(
       <SelectableCardListItem
@@ -160,13 +160,11 @@ describe('SelectableCardListItem', () => {
       />,
     )
 
-    // get the card container and try to click it
-    const cardContent = container.querySelector('[class*="MuiCardContent"]')
-    if (cardContent) {
-      fireEvent.click(cardContent)
-    }
+    // no radio is rendered while loading, so there is no keyboard tab stop
+    expect(screen.queryByRole('radio')).toBeNull()
 
-    // should not call onSelect due to pointerEvents: 'none'
-    expect(onSelect).not.toHaveBeenCalled()
+    // mouse clicks are blocked by pointer-events on the card root
+    const card = container.querySelector('.MuiCard-root')
+    expect(card).toHaveStyle('pointer-events: none')
   })
 })

--- a/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
+++ b/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
@@ -33,11 +33,21 @@ const SelectableCardListItem = ({
       <Radio
         aria-label={`Select ${title}`}
         checked={selected}
+        onChange={onSelect}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            onSelect()
+          }
+        }}
         sx={{
           p: 0,
           height: '1.25rem',
           width: '1.25rem',
           margin: '0.125rem 0rem',
+          '&:focus-visible': {
+            outline: 'none',
+          },
         }}
       />
       <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
@@ -70,7 +80,9 @@ const SelectableCardListItem = ({
   )
   return (
     <RcSesCard
+      component='button'
       onClick={onSelect}
+      tabIndex={isLoading ? 0 : -1}
       sx={{
         cursor: isLoading ? 'default' : 'pointer',
         pointerEvents: isLoading ? 'none' : 'auto',
@@ -78,8 +90,12 @@ const SelectableCardListItem = ({
         borderRadius: '0.75rem',
         padding: { xs: '1rem' },
         borderColor: selected ? palette.primary.main : palette.grey[300],
-        transition: 'all 0.2s ease',
+        transition: 'borderColor 0.2s ease, outline 0.2s ease',
         gap: { xs: '0.5rem', md: '0.25rem' },
+        '&:focus-visible, &:focus-within': {
+          borderColor: palette.grey[900],
+          outline: 'none',
+        },
       }}
       title={titleTemplate}
       slotProps={{

--- a/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
+++ b/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
@@ -33,10 +33,15 @@ const SelectableCardListItem = ({
       <Radio
         aria-label={`Select ${title}`}
         checked={selected}
-        onChange={onSelect}
+        onChange={(e) => {
+          e.stopPropagation()
+          onSelect()
+        }}
+        onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             e.preventDefault()
+            e.stopPropagation()
             onSelect()
           }
         }}
@@ -80,9 +85,7 @@ const SelectableCardListItem = ({
   )
   return (
     <RcSesCard
-      component='button'
       onClick={onSelect}
-      tabIndex={isLoading ? 0 : -1}
       sx={{
         cursor: isLoading ? 'default' : 'pointer',
         pointerEvents: isLoading ? 'none' : 'auto',
@@ -90,9 +93,9 @@ const SelectableCardListItem = ({
         borderRadius: '0.75rem',
         padding: { xs: '1rem' },
         borderColor: selected ? palette.primary.main : palette.grey[300],
-        transition: 'borderColor 0.2s ease, outline 0.2s ease',
+        transition: 'border-color 0.2s ease',
         gap: { xs: '0.5rem', md: '0.25rem' },
-        '&:focus-visible, &:focus-within': {
+        '&:has(input:focus-visible)': {
           borderColor: palette.grey[900],
           outline: 'none',
         },

--- a/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
+++ b/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
@@ -97,7 +97,6 @@ const SelectableCardListItem = ({
         gap: { xs: '0.5rem', md: '0.25rem' },
         '&:has(input:focus-visible)': {
           borderColor: palette.grey[900],
-          outline: 'none',
         },
       }}
       title={titleTemplate}

--- a/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
+++ b/src/components/common/SelectableCardList/components/SelectableCardListItem.tsx
@@ -50,9 +50,6 @@ const SelectableCardListItem = ({
           height: '1.25rem',
           width: '1.25rem',
           margin: '0.125rem 0rem',
-          '&:focus-visible': {
-            outline: 'none',
-          },
         }}
       />
       <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/SAV-6111

<!-- Link the related issue or ticket (e.g., Jira issue) -->

## 🧾 Summary

Added `borderColor` for the `&:focus-visible` and ensured focus work correctly with the TAB.

<!-- Brief explanation of what this PR does and why -->

## 📸 Screenshots

Updates can be checked here (updated!):

https://ses-react-storybook.registrucentras.lt/preview/SAV-6111-add-border-color-on-focus/

Black border appears when item is on focus. Pressing ENTER selects the radio button.

<img width="1104" height="723" alt="image" src="https://github.com/user-attachments/assets/a34f78f0-92bf-415f-87e0-1a030f81e76c" />


<!-- Visual proof of changes -->

## ✅ Checklist

* [ ] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [ ] UI matches approved design (Figma)
* [ ] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

N/A

<!-- Potential regressions or trade-offs -->
