### PR TITLE
SAV-6270: Tooltip component

### DIFF
--- a/src/components/common/Tooltip/index.test.tsx
+++ b/src/components/common/Tooltip/index.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import RcSesTooltip from './index'
+
+describe('RcSesTooltip', () => {
+  test('renders default trigger button', () => {
+    render(<RcSesTooltip title='Help text' />)
+
+    expect(
+      screen.getByRole('button', { name: 'components.Tooltip.trigger' }),
+    ).toBeInTheDocument()
+  })
+
+  test('opens tooltip on trigger click', async () => {
+    render(<RcSesTooltip title='Text' />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Text')
+  })
+
+  test('closes on pointerdown outside', async () => {
+    render(<RcSesTooltip title='Text' />)
+
+    fireEvent.click(screen.getByRole('button'))
+    await screen.findByRole('tooltip')
+
+    fireEvent.pointerDown(document.body)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+  })
+
+  test('keeps only one tooltip open at a time', async () => {
+    render(
+      <>
+        <RcSesTooltip title='A' />
+        <RcSesTooltip title='B' />
+      </>,
+    )
+
+    const [first, second] = screen.getAllByRole('button')
+
+    fireEvent.click(first)
+    await screen.findByRole('tooltip')
+
+    fireEvent.click(second)
+
+    await waitFor(() => {
+      const tooltips = screen.getAllByRole('tooltip')
+      expect(tooltips).toHaveLength(1)
+      expect(tooltips[0]).toHaveTextContent('B')
+    })
+  })
+
+  test('passes trigger slotProps to the default button', () => {
+    render(
+      <RcSesTooltip title='Text' slotProps={{ trigger: { 'aria-label': 'Custom' } }} />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Custom' })).toBeInTheDocument()
+  })
+
+  test('custom children trigger opens tooltip, chains onClick and forwards ref', async () => {
+    const onClick = vi.fn()
+    const ref = createRef<HTMLButtonElement>()
+
+    render(
+      <RcSesTooltip title='Text'>
+        <button type='button' ref={ref} onClick={onClick}>
+          Custom trigger
+        </button>
+      </RcSesTooltip>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Custom trigger' })
+    expect(ref.current).toBe(trigger)
+
+    fireEvent.click(trigger)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Text')
+  })
+})

--- a/src/components/common/Tooltip/index.tsx
+++ b/src/components/common/Tooltip/index.tsx
@@ -1,0 +1,167 @@
+import type { IconButtonProps, TooltipProps } from '@mui/material'
+import { Fade, IconButton, Tooltip } from '@mui/material'
+import { useForkRef } from '@mui/material/utils'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import QuestionIcon from '@/assets/icons/QuestionIcon'
+
+export type RcSesTooltipProps = {
+  title: string
+  placement?: TooltipProps['placement']
+} & (
+  | {
+      /* overrides for default trigger button */
+      slotProps?: { trigger?: Partial<IconButtonProps> }
+      children?: never
+    }
+  | {
+      slotProps?: never
+      /* custom trigger replaces default button, but should forward ref and define a11y name */
+      children: React.ReactElement
+    }
+)
+
+// only one tooltip should be visible, no need for context for that
+let closeCurrent: (() => void) | null = null
+
+const popperProps: TooltipProps['PopperProps'] = {
+  popperOptions: {
+    modifiers: [
+      { name: 'arrow', options: { padding: 14 } },
+      {
+        name: 'offset',
+        options: {
+          offset: ({ placement }: { placement: string }) => {
+            if (placement.endsWith('-end')) {
+              return [11, -4]
+            }
+
+            if (placement.endsWith('-start')) {
+              return [-11, -4]
+            }
+
+            return [0, -4]
+          },
+        },
+      },
+    ],
+  },
+}
+
+/**
+ * Controlled MUI Tooltip, ensures only one tooltip is visible and adds tap-to-dismiss to mobile
+ * (ClickAwayListener doesn't work with bubble itself)
+ */
+function RcSesTooltip({
+  title,
+  placement = 'top-start',
+  slotProps,
+  children,
+}: RcSesTooltipProps) {
+  const { t } = useTranslation('common')
+
+  const [open, setOpen] = React.useState(false)
+
+  const triggerRef = React.useRef<HTMLElement>(null)
+
+  // if children is used, child ref merge is needed
+  const childRef = (
+    children as (React.ReactElement & { ref?: React.Ref<HTMLElement> }) | undefined
+  )?.ref
+
+  const handleTriggerRef = useForkRef(triggerRef, childRef ?? null)
+
+  const hide = React.useCallback(() => setOpen(false), [])
+
+  const show = React.useCallback(() => {
+    if (closeCurrent !== hide) {
+      closeCurrent?.()
+      closeCurrent = hide
+    }
+
+    setOpen(true)
+  }, [hide])
+
+  // on mobile: tap anywhere to dismiss
+  React.useEffect(() => {
+    if (!open) {
+      return undefined
+    }
+
+    const onPointerDown = ({ target }: PointerEvent) => {
+      const element = target instanceof Element ? target : null
+
+      if (
+        triggerRef.current?.contains(element) ||
+        element?.closest('.MuiTooltip-popper')
+      ) {
+        return
+      }
+
+      hide()
+    }
+
+    document.addEventListener('pointerdown', onPointerDown)
+
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open, hide])
+
+  React.useEffect(
+    () => () => {
+      if (closeCurrent === hide) {
+        closeCurrent = null
+      }
+    },
+    [hide],
+  )
+
+  const { sx: triggerSx, ...triggerProps } = slotProps?.trigger ?? {}
+
+  const trigger = children ?? (
+    <IconButton
+      size='small'
+      aria-label={t('components.Tooltip.trigger')}
+      {...triggerProps}
+      sx={[
+        {
+          p: 0.25,
+          ml: 0.5,
+          verticalAlign: 'text-bottom',
+          color: 'grey.600',
+          '&:hover, &.Mui-focusVisible': { color: 'primary.main' },
+        },
+        ...(Array.isArray(triggerSx) ? triggerSx : [triggerSx]),
+      ]}
+    >
+      <QuestionIcon size={16} aria-hidden />
+    </IconButton>
+  )
+
+  return (
+    <Tooltip
+      title={title}
+      open={open}
+      describeChild
+      arrow
+      placement={placement}
+      leaveDelay={100}
+      disableTouchListener
+      TransitionComponent={Fade}
+      PopperProps={popperProps}
+      onOpen={show}
+      onClose={hide}
+    >
+      {/* same principle as in MUI Tooltip */}
+      {React.cloneElement(trigger, {
+        ref: handleTriggerRef,
+        onClick: (event: React.MouseEvent) => {
+          trigger.props.onClick?.(event)
+          show()
+        },
+      })}
+    </Tooltip>
+  )
+}
+
+export default RcSesTooltip

--- a/src/i18n/namespaces/common/en.json
+++ b/src/i18n/namespaces/common/en.json
@@ -14,6 +14,9 @@
     "SegmentedControl": {
       "options": "Options",
       "tabs": "Tabs"
+    },
+    "Tooltip": {
+      "trigger": "Explanation"
     }
   }
 }

--- a/src/i18n/namespaces/common/lt.json
+++ b/src/i18n/namespaces/common/lt.json
@@ -14,6 +14,9 @@
     "SegmentedControl": {
       "options": "Parinktys",
       "tabs": "Skirtukai"
+    },
+    "Tooltip": {
+      "trigger": "Paaiškinimas"
     }
   }
 }

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -26,6 +26,7 @@ import RcSesTab from '@/components/common/Tabs/Tab'
 import RcSesTabPanel from '@/components/common/Tabs/TabPanel'
 import RcSesTabs from '@/components/common/Tabs/Tabs'
 import RcSesTabsWrapper from '@/components/common/Tabs/TabsWrapper'
+import RcSesTooltip from '@/components/common/Tooltip'
 import RcSesFormControlWrapper from '@/components/form/components/FormControlWrapper'
 import RcSesCheckbox from '@/components/form/inputs/Checkbox'
 import RcSesCheckboxFormControl from '@/components/form/inputs/CheckboxFormControl'
@@ -98,6 +99,7 @@ export { RcSesSearchInput }
 export { RcSesSearchableField }
 export { RcSesSelect }
 export { RcSesTab, RcSesTabPanel, RcSesTabs, RcSesTabsWrapper }
+export { RcSesTooltip }
 export { RcSesTextField }
 export { DataPagination }
 export { ListWithIcons }

--- a/src/library/types.ts
+++ b/src/library/types.ts
@@ -6,6 +6,7 @@ import {
   RcSesSegmentedControlProps,
 } from '@/components/common/SegmentedControl'
 import { RcSesSegmentButtonProps } from '@/components/common/SegmentedControl/components/SegmentButton'
+import { RcSesTooltipProps } from '@/components/common/Tooltip'
 import { RcSesFormControlLabelProps } from '@/components/form/inputs/FormControlLabel'
 import { SimpleCheckboxProps } from '@/components/form/inputs/SimpleCheckbox'
 import { RcSesCardFormContainerProps } from '@/components/layout/ServiceFormContainer/CardFormContainer'
@@ -41,6 +42,7 @@ export type {
   RcSesFormControlLabelProps,
   RcSesLoadingSpinnerProps,
   RcSesSpinnerColor,
+  RcSesTooltipProps,
 }
 export type { RcSesDialogProps, DialogSize }
 export type { RcSesModalProps, ModalVariant }

--- a/src/stories/components/display/Tooltip.stories.tsx
+++ b/src/stories/components/display/Tooltip.stories.tsx
@@ -1,0 +1,67 @@
+import { Button, Typography } from '@mui/material'
+import type { Meta } from '@storybook/react'
+
+import RcSesTooltip from '../../../components/common/Tooltip'
+
+const meta = {
+  title: 'components/display/Tooltip',
+  component: RcSesTooltip,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Tooltip content',
+    },
+    placement: {
+      control: 'select',
+      options: ['top-start', 'top', 'top-end', 'bottom-start', 'bottom', 'bottom-end'],
+      description: 'Popper placement relative to the trigger',
+    },
+    slotProps: {
+      control: false,
+      description: 'Overrides for default trigger button',
+    },
+    children: {
+      control: false,
+      description: 'Custom trigger element, must forward ref!',
+    },
+  },
+} satisfies Meta<typeof RcSesTooltip>
+
+export default meta
+
+export const Default = {
+  args: {
+    title:
+      'Deklaruojant išvykimą iš Lietuvos nurodoma užsienio valstybė, į kurią išvykstama.',
+  },
+  render: (args: any) => (
+    <Typography>
+      Išvykimo valstybė
+      <RcSesTooltip {...args} />
+    </Typography>
+  ),
+} as const
+
+export const CustomTrigger = {
+  args: {
+    title: 'Papildoma informacija apie paslaugą.',
+  },
+  render: (args: any) => (
+    <RcSesTooltip {...args}>
+      <Button variant='text'>Mygtukas</Button>
+    </RcSesTooltip>
+  ),
+  parameters: {
+    docs: {
+      source: {
+        code: `<RcSesTooltip title="Papildoma informacija apie paslaugą.">
+  <Button variant="text">Mygtukas</Button>
+</RcSesTooltip>`,
+      },
+    },
+  },
+} as const

--- a/src/theme/light/MuiTooltip.ts
+++ b/src/theme/light/MuiTooltip.ts
@@ -1,0 +1,40 @@
+import { Components } from '@mui/material'
+
+import palette from '../palette'
+
+const MuiTooltip: Components['MuiTooltip'] = {
+  styleOverrides: {
+    tooltip: {
+      backgroundColor: '#fff',
+      color: palette.grey['900'],
+      maxWidth: 480,
+      padding: '12px 16px',
+      fontSize: '0.9rem',
+      fontWeight: 400,
+      lineHeight: 1.5,
+      borderRadius: '8px',
+      boxShadow: 'none',
+      filter: 'drop-shadow(0 6px 24px rgba(0, 0, 0, 0.16))',
+
+      '@keyframes rcses-tooltip': {
+        from: { transform: 'translate3d(0, var(--rcses-tooltip-shift, 6px), 0)' },
+        to: { transform: 'none' },
+      },
+
+      '@media (prefers-reduced-motion: no-preference)': {
+        animation: 'rcses-tooltip 160ms ease-out',
+      },
+
+      '[data-popper-placement*="bottom"] &': {
+        '--rcses-tooltip-shift': '-6px',
+      },
+    },
+
+    arrow: {
+      color: '#fff',
+      fontSize: '1rem',
+    },
+  },
+}
+
+export default MuiTooltip

--- a/src/theme/light/MuiTooltip.ts
+++ b/src/theme/light/MuiTooltip.ts
@@ -1,15 +1,15 @@
 import { Components } from '@mui/material'
 
-import palette from '../palette'
+import palette, { common } from '../palette'
 
 const MuiTooltip: Components['MuiTooltip'] = {
   styleOverrides: {
     tooltip: {
-      backgroundColor: '#fff',
+      backgroundColor: common.white,
       color: palette.grey['900'],
       maxWidth: 480,
       padding: '12px 16px',
-      fontSize: '0.9rem',
+      fontSize: '.875rem',
       fontWeight: 400,
       lineHeight: 1.5,
       borderRadius: '8px',
@@ -31,7 +31,7 @@ const MuiTooltip: Components['MuiTooltip'] = {
     },
 
     arrow: {
-      color: '#fff',
+      color: common.white,
       fontSize: '1rem',
     },
   },

--- a/src/theme/light/index.tsx
+++ b/src/theme/light/index.tsx
@@ -39,6 +39,7 @@ import MuiTable from '@/theme/light/MuiTable'
 import MuiTableCell from '@/theme/light/MuiTableCell'
 import MuiTabs from '@/theme/light/MuiTabs'
 import MuiTextField from '@/theme/light/MuiTextField'
+import MuiTooltip from '@/theme/light/MuiTooltip'
 import MuiTypography from '@/theme/light/MuiTypography'
 import themePalette from '@/theme/light/themePalette'
 
@@ -131,6 +132,7 @@ const theme = createTheme(themePalette, ltLT, enUS, {
     MuiTable,
     MuiTableCell,
     MuiTextField,
+    MuiTooltip,
     MuiTypography,
   },
 })


### PR DESCRIPTION
## 🔗 Task

SAV-6270

## 🧾 Summary

Adds focusable Tooltip component with arrow, based on MUI Tooltip with two extra features:
1. Only one tooltip is visible at once
2. Tap anywhere to dismiss on mobile

Renders a question mark icon by default, optionally accepts any child as the trigger.

## 📸 Screenshots

<img width="632" height="150" alt="image" src="https://github.com/user-attachments/assets/3db00f6b-a2b2-4784-93e7-7ab15a264076" />

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

None identified
