### PR TITLE
SAV-5935: InlineAlert component

### DIFF
--- a/src/components/common/InlineAlert/index.test.tsx
+++ b/src/components/common/InlineAlert/index.test.tsx
@@ -1,0 +1,125 @@
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import theme from '@/theme/light'
+
+import RcSesInlineAlert from './index'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const renderAlert = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+
+describe('RcSesInlineAlert', () => {
+  test('renders children', () => {
+    renderAlert(<RcSesInlineAlert>Alert message</RcSesInlineAlert>)
+    expect(screen.getByText('Alert message')).toBeInTheDocument()
+  })
+
+  describe('aria per variant', () => {
+    const politeVariants = ['neutral', 'info', 'success'] as const
+    const assertiveVariants = ['warning', 'error'] as const
+
+    politeVariants.forEach((variant) => {
+      test(`${variant} renders with role=status and aria-live=polite`, () => {
+        renderAlert(<RcSesInlineAlert variant={variant}>msg</RcSesInlineAlert>)
+        const alert = screen.getByRole('status')
+        expect(alert).toHaveAttribute('aria-live', 'polite')
+      })
+    })
+
+    assertiveVariants.forEach((variant) => {
+      test(`${variant} renders with role=alert and aria-live=assertive`, () => {
+        renderAlert(<RcSesInlineAlert variant={variant}>msg</RcSesInlineAlert>)
+        const alert = screen.getByRole('alert')
+        expect(alert).toHaveAttribute('aria-live', 'assertive')
+      })
+    })
+
+    test('default neutral (role=status)', () => {
+      renderAlert(<RcSesInlineAlert>msg</RcSesInlineAlert>)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+  })
+
+  describe('icon', () => {
+    test('is rendered and hidden from screen readers', () => {
+      const { container } = renderAlert(<RcSesInlineAlert>msg</RcSesInlineAlert>)
+      const icon = container.querySelector('svg[aria-hidden="true"]')
+      expect(icon).toBeInTheDocument()
+    })
+
+    test('is not rendered when showIcon=false', () => {
+      const { container } = renderAlert(
+        <RcSesInlineAlert showIcon={false}>Message</RcSesInlineAlert>,
+      )
+      expect(container.querySelector('svg')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('close button', () => {
+    test('renders with translated aria-label and calls onClose', () => {
+      const onClose = vi.fn()
+      renderAlert(<RcSesInlineAlert onClose={onClose}>Message</RcSesInlineAlert>)
+
+      const closeButton = screen.getByRole('button', { name: 'close' })
+      fireEvent.click(closeButton)
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    test('is not rendered when showClose=false', () => {
+      renderAlert(
+        <RcSesInlineAlert showClose={false} onClose={vi.fn()}>
+          msg
+        </RcSesInlineAlert>,
+      )
+      expect(screen.queryByRole('button', { name: 'close' })).not.toBeInTheDocument()
+    })
+
+    test('is not rendered with no onClose prop', () => {
+      renderAlert(<RcSesInlineAlert>Message</RcSesInlineAlert>)
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('action', () => {
+    test('renders label and calls onActionClick', () => {
+      const onActionClick = vi.fn()
+      renderAlert(
+        <RcSesInlineAlert actionLabel='Veiksmas' onActionClick={onActionClick}>
+          Message
+        </RcSesInlineAlert>,
+      )
+
+      const action = screen.getByRole('button', { name: 'Veiksmas' })
+      fireEvent.click(action)
+      expect(onActionClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('is not rendered when showAction={false}', () => {
+      renderAlert(
+        <RcSesInlineAlert showAction={false} actionLabel='Veiksmas'>
+          Message
+        </RcSesInlineAlert>,
+      )
+      expect(screen.queryByRole('button', { name: 'Veiksmas' })).not.toBeInTheDocument()
+    })
+  })
+
+  test('action comes before close in tab order', () => {
+    renderAlert(
+      <RcSesInlineAlert actionLabel='Veiksmas' onClose={vi.fn()}>
+        Message
+      </RcSesInlineAlert>,
+    )
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0]).toHaveTextContent('Veiksmas')
+    expect(buttons[1]).toHaveAttribute('aria-label', 'close')
+  })
+})

--- a/src/components/common/InlineAlert/index.tsx
+++ b/src/components/common/InlineAlert/index.tsx
@@ -1,0 +1,204 @@
+import { Box, Button, useTheme } from '@mui/material'
+import {
+  CheckCircleIcon,
+  InfoIcon,
+  WarningCircleIcon,
+  WarningIcon,
+} from '@phosphor-icons/react'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import CloseIcon from '@/assets/icons/CloseIcon'
+import { error, grey, primary, secondary, warning } from '@/theme/palette'
+
+export type RcSesInlineAlertProps = {
+  children: React.ReactNode
+  variant?: 'neutral' | 'info' | 'success' | 'warning' | 'error'
+  showIcon?: boolean
+  showClose?: boolean
+  showAction?: boolean
+  actionLabel?: string
+  onActionClick?: () => void
+  onClose?: () => void
+}
+
+type VariantStyle = {
+  background: string
+  border: string
+  iconColor: string
+  color: string
+  icon: typeof InfoIcon
+  role: 'status' | 'alert'
+}
+
+const variantStyles: Record<
+  NonNullable<RcSesInlineAlertProps['variant']>,
+  VariantStyle
+> = {
+  neutral: {
+    background: grey['50'],
+    border: grey['200'],
+    iconColor: grey['600'],
+    color: grey['900'],
+    icon: InfoIcon,
+    role: 'status',
+  },
+  info: {
+    background: primary['100'],
+    border: primary['300'],
+    iconColor: primary['600'],
+    color: primary['900'],
+    icon: InfoIcon,
+    role: 'status',
+  },
+  success: {
+    background: secondary['100'],
+    border: secondary['300'],
+    iconColor: secondary['600'],
+    color: secondary['900'],
+    icon: CheckCircleIcon,
+    role: 'status',
+  },
+  warning: {
+    background: warning['100'],
+    border: warning['300'],
+    iconColor: warning['600'],
+    color: warning['900'],
+    icon: WarningIcon,
+    role: 'alert',
+  },
+  error: {
+    background: error['100'],
+    border: error['300'],
+    iconColor: error['600'],
+    color: error['900'],
+    icon: WarningCircleIcon,
+    role: 'alert',
+  },
+}
+
+function RcSesInlineAlert(props: RcSesInlineAlertProps) {
+  const {
+    children,
+    variant = 'neutral',
+    showIcon = true,
+    showClose = true,
+    showAction = true,
+    actionLabel,
+    onActionClick,
+    onClose,
+  } = props
+  const { t } = useTranslation('input', { keyPrefix: 'components.RcSesInlineAlert' })
+
+  const theme = useTheme()
+
+  const variantStyle = variantStyles[variant]
+  const StatusIcon = variantStyle.icon
+
+  const hasAction = showAction && Boolean(actionLabel)
+  const hasClose = showClose && Boolean(onClose)
+
+  const wide = `@container (min-width: ${theme.breakpoints.values.sm}px)`
+
+  return (
+    <Box
+      role={variantStyle.role}
+      sx={{ containerType: 'inline-size', width: '100%' }}
+      aria-live={variantStyle.role === 'alert' ? 'assertive' : 'polite'}
+    >
+      <Box
+        sx={{
+          display: 'grid',
+          alignItems: 'start',
+          padding: theme.spacing(2.25, 1.85),
+          borderRadius: '0.5rem',
+          border: `1px solid ${variantStyle.border}`,
+          backgroundColor: variantStyle.background,
+          color: variantStyle.color,
+          gridTemplateColumns: 'auto 1fr auto',
+          gridTemplateAreas: '"icon text close" "icon action action"',
+          [wide]: {
+            gridTemplateColumns: 'auto 1fr max-content auto',
+            gridTemplateAreas: '"icon text action close"',
+          },
+        }}
+      >
+        {showIcon && (
+          <StatusIcon
+            size={21}
+            weight='regular'
+            color={variantStyle.iconColor}
+            focusable={false}
+            style={{ gridArea: 'icon', marginRight: theme.spacing(1.5) }}
+            aria-hidden
+          />
+        )}
+        <Box
+          sx={{
+            gridArea: 'text',
+            minWidth: 0,
+            fontSize: theme.typography.body2.fontSize,
+            lineHeight: '1.375rem',
+            a: { color: 'inherit' },
+          }}
+        >
+          {children}
+        </Box>
+        {hasAction && (
+          <Button
+            variant='link'
+            sx={{
+              gridArea: 'action',
+              justifySelf: 'end',
+              height: 'auto',
+              minWidth: 0,
+              padding: 0,
+              fontSize: theme.typography.body2.fontSize,
+              fontWeight: theme.typography.fontWeightMedium,
+              lineHeight: '1.375rem',
+              whiteSpace: 'nowrap',
+              marginTop: theme.spacing(0.5),
+              [wide]: {
+                marginTop: 0,
+                marginLeft: theme.spacing(1.5),
+              },
+            }}
+            onClick={onActionClick}
+          >
+            {actionLabel}
+          </Button>
+        )}
+        {hasClose && (
+          <Box
+            component='button'
+            type='button'
+            onClick={onClose}
+            aria-label={t('close')}
+            sx={{
+              gridArea: 'close',
+              marginLeft: theme.spacing(1.5),
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 0,
+              border: 'none',
+              background: 'none',
+              cursor: 'pointer',
+              opacity: 0.8,
+              '&:hover': { opacity: 1 },
+            }}
+          >
+            <CloseIcon
+              size={22}
+              fillColor={variantStyle.color}
+              focusable={false}
+              aria-hidden
+            />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export default RcSesInlineAlert

--- a/src/i18n/namespaces/input/en.json
+++ b/src/i18n/namespaces/input/en.json
@@ -38,6 +38,10 @@
       "required": "Field is required"
     },
 
+    "RcSesInlineAlert": {
+      "close": "Close"
+    },
+
     "RcSesNumberStepper": {
       "add": "Add",
       "subtract": "Subtract"

--- a/src/i18n/namespaces/input/lt.json
+++ b/src/i18n/namespaces/input/lt.json
@@ -38,6 +38,10 @@
       "required": "Laukas yra privalomas"
     },
 
+    "RcSesInlineAlert": {
+      "close": "Uždaryti"
+    },
+
     "RcSesNumberStepper": {
       "add": "Pridėti",
       "subtract": "Atimti"

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -14,6 +14,7 @@ import RcSesCard from '@/components/common/Card'
 import DataPagination from '@/components/common/DataPagination'
 import RcSesIconWithCircularBackground from '@/components/common/IconWithCircularBackground'
 import RcSesImageCard from '@/components/common/ImageCard'
+import RcSesInlineAlert from '@/components/common/InlineAlert'
 import ListWithIcons from '@/components/common/ListWithIcons'
 import RcSesSegmentedControl from '@/components/common/SegmentedControl'
 import RcSesSnackbar from '@/components/common/Snackbar'
@@ -80,6 +81,7 @@ export {
   RcSesDialog,
   RcSesFooter,
   RcSesImageCard,
+  RcSesInlineAlert,
   RcSesSnackbar,
   RcSesSnackbarProvider,
   RcSesModal,
@@ -106,6 +108,7 @@ export { RcSesFormControlLabel }
 export { SelectableCardList }
 export type * from './types'
 export type { SnackbarSize, SnackbarState } from '@/components/common/Snackbar/types'
+export type { RcSesInlineAlertProps } from '@/components/common/InlineAlert'
 
 export {
   RcSesServiceFormActions,

--- a/src/stories/components/feedback/InlineAlert.stories.tsx
+++ b/src/stories/components/feedback/InlineAlert.stories.tsx
@@ -1,0 +1,77 @@
+import { Stack } from '@mui/material'
+import { Meta, StoryObj } from '@storybook/react'
+
+import RcSesInlineAlert from '@/components/common/InlineAlert'
+
+const text = 'Pranešimo tekstas. Pakeisk turinį pagal kontekstą.'
+const longText =
+  'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Maiores, ' +
+  'nulla quae? Aliquam aperiam aut consequuntur cum debitis dolor eum explicabo, ' +
+  'laborum molestias placeat quae quos sequi sunt tempore.'
+
+const variants = ['neutral', 'info', 'success', 'warning', 'error'] as const
+
+const meta: Meta<typeof RcSesInlineAlert> = {
+  title: 'components/feedback/InlineAlert',
+  component: RcSesInlineAlert,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: variants },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof RcSesInlineAlert>
+
+export const Main: Story = {
+  render: () => (
+    <Stack spacing={2}>
+      {variants.map((variant) => (
+        <RcSesInlineAlert
+          key={variant}
+          variant={variant}
+          actionLabel='Veiksmas'
+          onClose={() => {}}
+        >
+          {text}
+        </RcSesInlineAlert>
+      ))}
+    </Stack>
+  ),
+}
+
+export const Combinations: Story = {
+  render: () => (
+    <Stack spacing={2}>
+      <RcSesInlineAlert>{text}</RcSesInlineAlert>
+
+      <RcSesInlineAlert showIcon={false}>{text}</RcSesInlineAlert>
+
+      <RcSesInlineAlert onClose={() => {}}>{text}</RcSesInlineAlert>
+
+      <RcSesInlineAlert actionLabel='Veiksmas'>{text}</RcSesInlineAlert>
+
+      <RcSesInlineAlert actionLabel='Veiksmas' onClose={() => {}}>
+        {text}
+      </RcSesInlineAlert>
+    </Stack>
+  ),
+}
+
+export const LongText: Story = {
+  render: () => (
+    <Stack spacing={2}>
+      {variants.map((variant) => (
+        <RcSesInlineAlert
+          key={variant}
+          variant={variant}
+          actionLabel='Veiksmas'
+          onClose={() => {}}
+        >
+          {longText}
+        </RcSesInlineAlert>
+      ))}
+    </Stack>
+  ),
+}


### PR DESCRIPTION
## 🔗 Task

SAV-5935

## 🧾 Summary

New InlineAlert component with 5 variants. Based on container queries for optimal UX on mobile and in small parent containers on desktop

## 📸 Screenshots

<img width="654" height="388" alt="inline-alert-1" src="https://github.com/user-attachments/assets/fbde948e-60dd-4173-b412-9dc616d96e3a" />

<img width="651" height="381" alt="inline-alert-2" src="https://github.com/user-attachments/assets/413be820-5b1c-4c3c-b17c-7a07dcfe10c2" />

<img width="427" height="649" alt="inline-alert-3" src="https://github.com/user-attachments/assets/b74ddca2-52d7-4056-9b0e-f3297fbd25b4" />

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

None identified
