### PR TITLE
Sav 6270 select controller slot props

### DIFF
--- a/src/components/form/inputs/FileDropzone.tsx
+++ b/src/components/form/inputs/FileDropzone.tsx
@@ -55,6 +55,7 @@ function RcSesFileDropzone(props: Props) {
     control,
     name,
     rules,
+    ...slotProps?.controller,
   })
 
   const onDrop = useCallback((acceptedFiles: Blob[]) => {

--- a/src/components/form/inputs/FileUpload.tsx
+++ b/src/components/form/inputs/FileUpload.tsx
@@ -57,6 +57,7 @@ function RcSesFileUpload(props: Props) {
     control,
     name,
     rules,
+    ...slotProps?.controller,
   })
 
   const handleChange = (e: { target: { files: any } }) => onChange(e.target.files)

--- a/src/components/form/inputs/NumberStepper.tsx
+++ b/src/components/form/inputs/NumberStepper.tsx
@@ -136,6 +136,7 @@ function RcSesNumberStepper(props: Props) {
     control,
     name,
     rules,
+    ...slotProps?.controller,
   })
 
   React.useEffect(() => {

--- a/src/components/form/inputs/RadioButtonGroup.test.tsx
+++ b/src/components/form/inputs/RadioButtonGroup.test.tsx
@@ -1,0 +1,71 @@
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import theme from '@/theme/light'
+
+import RcSesRadioButtonGroup from './RadioButtonGroup'
+
+const options = [
+  { label: 'Fizinis asmuo', value: 'natural' },
+  { label: 'Juridinis asmuo', value: 'legal' },
+]
+
+type TestWrapperProps = {
+  shouldUnregister?: boolean
+}
+
+const TestWrapper = ({ shouldUnregister }: TestWrapperProps) => {
+  const { control, getValues } = useForm({
+    defaultValues: { ownerType: 'natural' },
+  })
+  const [mounted, setMounted] = useState(true)
+  const [formValues, setFormValues] = useState('')
+
+  const slotProps =
+    shouldUnregister === undefined ? undefined : { controller: { shouldUnregister } }
+
+  return (
+    <ThemeProvider theme={theme}>
+      {mounted && (
+        <RcSesRadioButtonGroup
+          id='ownerType'
+          name='ownerType'
+          control={control}
+          label='Savininko tipas'
+          options={options}
+          slotProps={slotProps}
+        />
+      )}
+
+      <button type='button' onClick={() => setMounted(false)}>
+        Hide
+      </button>
+      <button type='button' onClick={() => setFormValues(JSON.stringify(getValues()))}>
+        Read
+      </button>
+      <div data-testid='form-values'>{formValues}</div>
+    </ThemeProvider>
+  )
+}
+
+describe('RcSesRadioButtonGroup', () => {
+  test('keeps the value in the form by default when the field unmounts', () => {
+    render(<TestWrapper />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Read' }))
+
+    expect(screen.getByTestId('form-values')).toHaveTextContent('natural')
+  })
+
+  test('drops the value when slotProps.controller turns shouldUnregister on', () => {
+    render(<TestWrapper shouldUnregister />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Read' }))
+
+    expect(screen.getByTestId('form-values')).not.toHaveTextContent('natural')
+  })
+})

--- a/src/components/form/inputs/RadioButtonGroup.tsx
+++ b/src/components/form/inputs/RadioButtonGroup.tsx
@@ -66,6 +66,7 @@ function UnstyledRcSesRadioButtonGroup(props: Props) {
     control,
     name,
     rules,
+    ...slotProps?.controller,
   })
 
   return (

--- a/src/components/form/inputs/Select/index.test.tsx
+++ b/src/components/form/inputs/Select/index.test.tsx
@@ -1,5 +1,6 @@
 import { ThemeProvider } from '@mui/material/styles'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import theme from '@/theme/light'
@@ -20,6 +21,44 @@ const options = [
     label: 'Trumpas pasirinkimas',
   },
 ]
+
+type UnregisterTestWrapperProps = {
+  shouldUnregister?: boolean
+}
+
+const UnregisterTestWrapper = ({ shouldUnregister }: UnregisterTestWrapperProps) => {
+  const { control, getValues } = useForm({
+    defaultValues: { selection: 'short-option' as string | null },
+  })
+  const [mounted, setMounted] = useState(true)
+  const [formValues, setFormValues] = useState('')
+
+  const slotProps =
+    shouldUnregister === undefined ? undefined : { controller: { shouldUnregister } }
+
+  return (
+    <ThemeProvider theme={theme}>
+      {mounted && (
+        <RcSesSelect
+          id='selection'
+          name='selection'
+          control={control}
+          label='Pasirinkti'
+          options={options}
+          slotProps={slotProps}
+        />
+      )}
+
+      <button type='button' onClick={() => setMounted(false)}>
+        Hide
+      </button>
+      <button type='button' onClick={() => setFormValues(JSON.stringify(getValues()))}>
+        Read
+      </button>
+      <div data-testid='form-values'>{formValues}</div>
+    </ThemeProvider>
+  )
+}
 
 const TestWrapper = ({ defaultValue = null }: TestWrapperProps) => {
   const { control } = useForm({
@@ -98,5 +137,23 @@ describe('RcSesSelect', () => {
     render(<TestWrapper defaultValue='long-option' />)
 
     expect(screen.getByRole('combobox')).toHaveAttribute('readonly')
+  })
+
+  test('drops the value from the form by default when the field unmounts', () => {
+    render(<UnregisterTestWrapper />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Read' }))
+
+    expect(screen.getByTestId('form-values')).not.toHaveTextContent('short-option')
+  })
+
+  test('keeps the value when slotProps.controller turns shouldUnregister off', () => {
+    render(<UnregisterTestWrapper shouldUnregister={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Read' }))
+
+    expect(screen.getByTestId('form-values')).toHaveTextContent('short-option')
   })
 })

--- a/src/components/form/inputs/Select/index.tsx
+++ b/src/components/form/inputs/Select/index.tsx
@@ -42,6 +42,7 @@ type Props = Pick<TControllerProps, ImmediateControllerProps> &
     onInputChange?: AutocompleteProps<Option, boolean, boolean, false>['onInputChange']
 
     slotProps?: {
+      controller?: Partial<Omit<TControllerProps, ImmediateControllerProps>>
       field?: Partial<
         Omit<
           AutocompleteProps<Option, boolean, boolean, false>,
@@ -94,6 +95,7 @@ function RcSesSelect(props: Props) {
     name,
     rules,
     shouldUnregister: true,
+    ...slotProps?.controller,
   })
 
   const hasError = !!errors

--- a/src/stories/components/display/AdvancedList.stories.tsx
+++ b/src/stories/components/display/AdvancedList.stories.tsx
@@ -1,5 +1,7 @@
 import {
   Avatar,
+  Box,
+  Checkbox,
   FormControl,
   FormControlLabel,
   FormLabel,
@@ -7,15 +9,18 @@ import {
   RadioGroup,
   Stack,
   TextField,
+  Typography,
 } from '@mui/material'
 import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
+import { useForm } from 'react-hook-form'
 
 import InfoFillIcon from '@/assets/icons/InfoFillIcon'
 import NotePencilIcon from '@/assets/icons/NotePencilIcon'
 import TrashIcon from '@/assets/icons/TrashIcon'
 import UserIcon from '@/assets/icons/UserIcon'
 import AdvancedList, { type AdvancedListItemData } from '@/components/common/AdvancedList'
+import RcSesSelect from '@/components/form/inputs/Select'
 
 const buildItems = (): AdvancedListItemData[] =>
   Array.from({ length: 8 }, (_, index) => ({
@@ -189,6 +194,132 @@ const OwnerTypeExpandStory = () => {
 export const OwnerTypeExpand: Story = {
   name: 'Preset: savininko tipas (radio + expand)',
   render: () => <OwnerTypeExpandStory />,
+}
+
+type OwnerBranchFormModel = {
+  individual: { municipality: string | null }
+  legalEntity: { legalForm: string | null }
+}
+
+const MUNICIPALITY_OPTIONS = [
+  { value: 'vilnius', label: 'Vilniaus m. sav.' },
+  { value: 'kaunas', label: 'Kauno m. sav.' },
+]
+
+const LEGAL_FORM_OPTIONS = [
+  { value: 'uab', label: 'UAB' },
+  { value: 'mb', label: 'Mažoji bendrija' },
+]
+
+const PANEL_SX = {
+  backgroundColor: 'grey.100',
+  borderRadius: '.5rem',
+  fontSize: '.75rem',
+  m: 0,
+  overflowX: 'auto',
+  p: 1.5,
+}
+
+const RadioBranchFormStory = () => {
+  const [ownerTypeId, setOwnerTypeId] = useState(OWNER_TYPE_OPTIONS[0].id)
+  const [shouldUnregister, setShouldUnregister] = useState(true)
+
+  const { control, watch } = useForm<OwnerBranchFormModel>({
+    defaultValues: {
+      individual: { municipality: null },
+      legalEntity: { legalForm: null },
+    },
+  })
+
+  const formState = watch()
+
+  // The non-selected branch stays in form state when shouldUnregister is off, so the
+  // submitted payload is built from the selected branch instead of the whole form.
+  const payload =
+    ownerTypeId === 'owner-legal'
+      ? { legalEntity: formState.legalEntity }
+      : { individual: formState.individual }
+
+  // Only the selected branch renders its fields, so switching unmounts the other one -
+  // that unmount is what makes shouldUnregister observable.
+  const renderBranchFields = (optionId: string) => {
+    if (optionId !== ownerTypeId) return undefined
+
+    if (optionId === 'owner-legal') {
+      return (
+        <RcSesSelect
+          id='owner-branch-legal-form'
+          control={control}
+          name='legalEntity.legalForm'
+          label='Juridinio asmens forma'
+          options={LEGAL_FORM_OPTIONS}
+          slotProps={{ controller: { shouldUnregister } }}
+        />
+      )
+    }
+
+    return (
+      <RcSesSelect
+        id='owner-branch-municipality'
+        control={control}
+        name='individual.municipality'
+        label='Savivaldybė'
+        options={MUNICIPALITY_OPTIONS}
+        slotProps={{ controller: { shouldUnregister } }}
+      />
+    )
+  }
+
+  const items: AdvancedListItemData[] = OWNER_TYPE_OPTIONS.map((option) => ({
+    id: option.id,
+    title: option.title,
+    state: ownerTypeId === option.id ? 'selected' : 'rest',
+    leading: {
+      type: 'radio',
+      name: 'owner-branch-form',
+      checked: ownerTypeId === option.id,
+      onChange: () => setOwnerTypeId(option.id),
+    },
+    expanded: ownerTypeId === option.id,
+    expandedContent: renderBranchFields(option.id),
+  }))
+
+  return (
+    <Stack gap={2}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={shouldUnregister}
+            onChange={(event) => setShouldUnregister(event.target.checked)}
+          />
+        }
+        label='slotProps.controller.shouldUnregister (bibliotekos numatytoji reikšmė - true)'
+      />
+
+      <AdvancedList items={items} />
+
+      <Stack direction={{ xs: 'column', md: 'row' }} gap={2}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant='body2'>Formos būsena</Typography>
+          <Box component='pre' sx={PANEL_SX}>
+            {JSON.stringify(formState, null, 2)}
+          </Box>
+        </Box>
+
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant='body2'>Submit payload (tik pasirinkta šaka)</Typography>
+          <Box component='pre' sx={PANEL_SX}>
+            {JSON.stringify(payload, null, 2)}
+          </Box>
+        </Box>
+      </Stack>
+    </Stack>
+  )
+}
+
+export const RadioBranchForm: Story = {
+  name: 'Preset: radio šakos su react-hook-form',
+  render: () => <RadioBranchFormStory />,
 }
 
 const FigmaAnatomyStory = () => {


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/browse/SAV-6270

## 🧾 Summary

`RcSesSelect` hardcoded `shouldUnregister: true`, so a consumer could not keep the
value when the field unmounts. This blocks the AdvancedList radio branches, where
switching a radio variant unmounts the fields of the branch being left and the form
loses the data.

`RcSesSearchInput` and `RcSesSearchableField` already allow this through
`slotProps.controller`. Select now does the same, with the default kept at
`shouldUnregister: true`, so nothing changes for existing consumers.

While checking the other form inputs, `RcSesRadioButtonGroup`, `RcSesNumberStepper`,
`RcSesFileUpload` and `RcSesFileDropzone` turned out to declare `controller` in their
public `slotProps` type without ever spreading it into `useController`, so the prop
type-checked and did nothing. They now spread it too.

Also added a Storybook story under `components/display/AdvancedList` that runs the
radio branches through react-hook-form, with a `shouldUnregister` toggle and panels
showing the form state next to the branch-filtered submit payload.

## 📸 Screenshots

<!-- Storybook: components/display/AdvancedList -> "Preset: radio šakos su react-hook-form" -->

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [ x] Tests added/updated
* [ x] UI matches approved design (Figma)
* [ x] Accessibility reviewed (keyboard navigation, labels, semantics)

## ⚠️ Risks

LOW
