### PR TITLE
docs(storybook): document the validation-error pattern

### DIFF
--- a/src/stories/components/display/SelectableCardList.stories.tsx
+++ b/src/stories/components/display/SelectableCardList.stories.tsx
@@ -9,6 +9,7 @@ import SelectableCardList, {
   type SelectableCardListItemData,
   type SelectableCardListProps,
 } from '@/components/common/SelectableCardList'
+import RcSesFormControlWrapper from '@/components/form/components/FormControlWrapper'
 
 const getListItems = (index: number): ListWithIconsItemData[] => {
   switch (index) {
@@ -61,8 +62,11 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component:
+        component: [
           'Paginates items client-side, showing 5 per page on desktop and 3 per page on mobile (below the `md` breakpoint). The page resets to 1 whenever the page size changes, e.g. when resizing across the breakpoint.',
+          '',
+          'The `error` prop is a data-loading failure state: whatever node it receives is rendered **instead of** the cards and the pagination. It is not meant for form validation messages - for those wrap the list in `RcSesFormControlWrapper` and pass `errors`, which keeps the cards visible and shows the message below them. Compare the `Error` and `ValidationError` stories.',
+        ].join('\n'),
       },
     },
   },
@@ -131,5 +135,33 @@ export const Loading: Story = {
 export const Error: Story = {
   args: {
     error: 'Unable to load selectable cards. Please try again.',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Data-loading failure state. `items` is still populated here, yet the cards and the pagination are replaced by the `error` node - that is what this prop does. Use it when the list could not be fetched, not to report an invalid selection.',
+      },
+    },
+  },
+}
+
+export const ValidationError: Story = {
+  render: (args) => (
+    <RcSesFormControlWrapper
+      label='Service option'
+      required
+      errors={{ type: 'required', message: 'Select one of the options' }}
+    >
+      <SelectableCardListStory {...args} onSelect={args.onSelect ?? (() => {})} />
+    </RcSesFormControlWrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The way to report an invalid selection: wrap the list in `RcSesFormControlWrapper` and pass the react-hook-form `fieldState.error` as `errors`. The cards stay selectable and the message renders below them. Leave the list's own `error` prop unset.",
+      },
+    },
   },
 }

--- a/src/stories/components/form/FormControlWrapper.stories.tsx
+++ b/src/stories/components/form/FormControlWrapper.stories.tsx
@@ -33,3 +33,26 @@ export const Default: Story = {
     </RcSesFormControlWrapper>
   ),
 }
+
+export const WithError: Story = {
+  args: {
+    label: 'Label',
+    hideLabel: false,
+    labelOnTop: false,
+    required: true,
+    errors: { type: 'required', message: 'This field is required' },
+  },
+  render: (args) => (
+    <RcSesFormControlWrapper {...args}>
+      <TextField id='input' placeholder='Type text here' size='small' fullWidth error />
+    </RcSesFormControlWrapper>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass the react-hook-form `fieldState.error` as `errors` and the message renders below the field, leaving the field itself untouched. This is the validation pattern for any wrapped control, including ones that are not inputs - see `SelectableCardList` → `ValidationError`. When `errors.type` is `required` and no `message` is set, a translated fallback is shown instead.',
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Why

A consumer team hit what looked like a bug: passing `fieldState.error?.message` into `SelectableCardList`'s `error` prop made every card disappear, leaving only the message.

That is the prop working as designed. `error` is a data-loading failure state - the node it receives is rendered instead of the cards and the pagination (`SelectableCardList/index.tsx`, `error != null ? error : ...`), and the unit test asserts the list is hidden. It has behaved this way since the component was added.

The problem is discoverability. The only error-shaped example in Storybook was the `Error` story, which looks like a generic error slot, and `FormControlWrapper` had no `errors` example at all - so nothing anywhere showed the correct validation pattern.

## What changed

Stories only, no component or behaviour changes.

**SelectableCardList**
- new `ValidationError` story: the list wrapped in `RcSesFormControlWrapper` with `errors`, cards stay visible and selectable, message renders below
- `Error` story keeps its name (existing Storybook links stay valid) and gains a description stating `items` is populated yet still replaced, and that this is a data-loading state
- component description now spells out `error` vs the wrapper's `errors` and points at the two stories

**FormControlWrapper**
- new `WithError` story, plus a note that the pattern applies to any wrapped control including non-inputs, and that a translated fallback is shown when `errors.type` is `required` with no `message`

